### PR TITLE
Team games for conservative AIs

### DIFF
--- a/conservative_ai/agent.py
+++ b/conservative_ai/agent.py
@@ -93,7 +93,10 @@ class ConservativeAgent(agent.Agent):
         if role == "first":
             # First ally looks ahead to the situation the last ally will face 
             effective_last_bet = max(last_bet + N - 1, bet_floor - 1)
-            
+
+            if effective_last_bet >= check_action_id - 1:
+                return check_action_id if last_bet > -1 else 0
+
             # Temporarily pretend to be the last ally to calculate using their jokers
             original_cp_nickname = game_state["cp_nickname"]
             game_state["cp_nickname"] = last_ally_nickname

--- a/conservative_ai/agent.py
+++ b/conservative_ai/agent.py
@@ -108,7 +108,7 @@ class ConservativeAgent(agent.Agent):
             sampling_weights = compute_sampling_weights(bet_probs_betting)
 
         # Check/Bet Evaluation (alone and first can check; last cannot)
-        if role in {"alone", "first"} and last_bet is not None and last_bet < check_action_id:
+        if role in {"alone", "first"} and last_bet > -1 and last_bet < check_action_id:
             prob_last_bet_exists = dynamic_probabilities.get_bet_probabilities(game_state, for_betting=False, specific_action_id=last_bet)
             
             if prob_last_bet_exists == 0:

--- a/conservative_ai/agent.py
+++ b/conservative_ai/agent.py
@@ -3,7 +3,6 @@ from shared.ai import agent
 from shared.probabilities import dynamic_probabilities
 from shared.game_utils import GameRules
 
-
 def normalise(arr):
     sum_arr = sum(arr)
     if sum_arr:
@@ -36,6 +35,46 @@ class ConservativeAgent(agent.Agent):
         if game_state.get("history"):
             last_bet = game_state.get("history")[-1]["action_id"]
 
+        # Determine Adjacency Role
+        players = game_state.get("players", [])
+        cp_nickname = game_state.get("cp_nickname")
+        cp_index = next((i for i, p in enumerate(players) if p.get("nickname") == cp_nickname), -1)
+        
+        N = 1
+        if cp_index != -1 and players[cp_index].get("team") is not None:
+            cp_team = players[cp_index].get("team")
+            
+            # Count contiguous allies forward
+            forward_allies = 0
+            for i in range(1, len(players)):
+                idx = (cp_index + i) % len(players)
+                if players[idx].get("team") == cp_team:
+                    forward_allies += 1
+                else:
+                    break
+                    
+            # Count contiguous allies backward
+            backward_allies = 0
+            for i in range(1, len(players)):
+                idx = (cp_index - i) % len(players)
+                if players[idx].get("team") == cp_team:
+                    backward_allies += 1
+                else:
+                    break
+            
+            if forward_allies > 0 or backward_allies > 0:
+                N = 1 + forward_allies + backward_allies
+                if backward_allies == 0:
+                    role = "first"
+                elif forward_allies == 0:
+                    role = "last"
+                else:
+                    role = "middle"
+            else:
+                role = "alone"
+        else:
+            role = "alone"
+
         bet_probs_generic = dynamic_probabilities.get_generic_bet_probabilities(game_state, last_bet=last_bet)
         bet_floor = 0
         for i, prob in enumerate(bet_probs_generic):
@@ -44,10 +83,23 @@ class ConservativeAgent(agent.Agent):
         
         effective_last_bet = max(last_bet if last_bet is not None else -1, bet_floor - 1)
 
+        # Middle role: just raise by 1
+        if role == "middle":
+            return min(effective_last_bet + 1, check_action_id)
+
         bet_probs_betting = dynamic_probabilities.get_bet_probabilities(game_state, for_betting=True, last_bet=effective_last_bet)
         sampling_weights = compute_sampling_weights(bet_probs_betting)
 
-        if last_bet is not None and last_bet < check_action_id:
+        # First role: get weights
+        if role == "first":
+            start_zero = effective_last_bet + 1
+            end_zero = min(effective_last_bet + 1 + N - 1, len(sampling_weights))
+            for i in range(start_zero, end_zero):
+                sampling_weights[i] = 0.0
+            sampling_weights = normalise(sampling_weights)
+
+        # Check/Bet Evaluation
+        if role in {"alone", "first"} and last_bet is not None and last_bet < check_action_id:
             prob_last_bet_exists = dynamic_probabilities.get_bet_probabilities(game_state, for_betting=False, specific_action_id=last_bet)
             
             if prob_last_bet_exists == 0:
@@ -70,8 +122,11 @@ class ConservativeAgent(agent.Agent):
         if not any(sampling_weights):
             return check_action_id if last_bet is not None else 0
 
-        sampled_action = random.choices(range(len(sampling_weights)), weights=sampling_weights, k=1)[0]
-        return sampled_action
+        # By this point we've chosen not to check, so we bet
+        if role == "first":
+            return min(effective_last_bet + 1, check_action_id)
+        else: # Alone or last role
+            return random.choices(range(len(sampling_weights)), weights=sampling_weights, k=1)[0]
 
     def run(self):
         """

--- a/conservative_ai/agent.py
+++ b/conservative_ai/agent.py
@@ -20,7 +20,6 @@ class ConservativeAgent(agent.Agent):
         Autonomous AI Agent class to play Blef.
         A simple, conservative agent.
     """
-
     def __init__(self, base_url=None):
         super(ConservativeAgent, self).__init__(base_url)
         self.nickname = "Dazhbog"
@@ -34,30 +33,36 @@ class ConservativeAgent(agent.Agent):
         last_bet = None
         if game_state.get("history"):
             last_bet = game_state.get("history")[-1]["action_id"]
+        else:
+            last_bet = -1
 
-        # Determine Adjacency Role
-        players = game_state.get("players", [])
+        # Filter eliminated players and determine adjacency role
+        all_players = game_state.get("players", [])
+        active_players = [p for p in all_players if p.get("n_cards", 0) > 0]
         cp_nickname = game_state.get("cp_nickname")
-        cp_index = next((i for i, p in enumerate(players) if p.get("nickname") == cp_nickname), -1)
+        cp_index = next((i for i, p in enumerate(active_players) if p.get("nickname") == cp_nickname), -1)
         
         N = 1
-        if cp_index != -1 and players[cp_index].get("team") is not None:
-            cp_team = players[cp_index].get("team")
+        role = "alone"
+        last_ally_nickname = cp_nickname
+
+        if cp_index != -1 and active_players[cp_index].get("team") is not None:
+            cp_team = active_players[cp_index].get("team")
             
             # Count contiguous allies forward
             forward_allies = 0
-            for i in range(1, len(players)):
-                idx = (cp_index + i) % len(players)
-                if players[idx].get("team") == cp_team:
+            for i in range(1, len(active_players)):
+                idx = (cp_index + i) % len(active_players)
+                if active_players[idx].get("team") == cp_team:
                     forward_allies += 1
                 else:
                     break
                     
             # Count contiguous allies backward
             backward_allies = 0
-            for i in range(1, len(players)):
-                idx = (cp_index - i) % len(players)
-                if players[idx].get("team") == cp_team:
+            for i in range(1, len(active_players)):
+                idx = (cp_index - i) % len(active_players)
+                if active_players[idx].get("team") == cp_team:
                     backward_allies += 1
                 else:
                     break
@@ -66,39 +71,43 @@ class ConservativeAgent(agent.Agent):
                 N = 1 + forward_allies + backward_allies
                 if backward_allies == 0:
                     role = "first"
+                    last_ally_idx = (cp_index + forward_allies) % len(active_players)
+                    last_ally_nickname = active_players[last_ally_idx].get("nickname")
                 elif forward_allies == 0:
                     role = "last"
                 else:
                     role = "middle"
-            else:
-                role = "alone"
-        else:
-            role = "alone"
 
+        # Extract Generic Probabilities and Bet Floor
         bet_probs_generic = dynamic_probabilities.get_generic_bet_probabilities(game_state, last_bet=last_bet)
         bet_floor = 0
         for i, prob in enumerate(bet_probs_generic):
             if prob == 1.0:
                 bet_floor = i
-        
-        effective_last_bet = max(last_bet if last_bet is not None else -1, bet_floor - 1)
 
         # Middle role: just raise by 1
         if role == "middle":
-            return min(effective_last_bet + 1, check_action_id)
-
-        bet_probs_betting = dynamic_probabilities.get_bet_probabilities(game_state, for_betting=True, last_bet=effective_last_bet)
-        sampling_weights = compute_sampling_weights(bet_probs_betting)
+            return min(last_bet + 1, check_action_id)
 
         # First role: get weights
         if role == "first":
-            start_zero = effective_last_bet + 1
-            end_zero = min(effective_last_bet + 1 + N - 1, len(sampling_weights))
-            for i in range(start_zero, end_zero):
-                sampling_weights[i] = 0.0
-            sampling_weights = normalise(sampling_weights)
+            # First ally looks ahead to the situation the last ally will face 
+            effective_last_bet = max(last_bet + N - 1, bet_floor - 1)
+            
+            # Temporarily pretend to be the last ally to calculate using their jokers
+            original_cp_nickname = game_state["cp_nickname"]
+            game_state["cp_nickname"] = last_ally_nickname
+            bet_probs_betting = dynamic_probabilities.get_bet_probabilities(game_state, for_betting=True, last_bet=effective_last_bet)
+            game_state["cp_nickname"] = original_cp_nickname
+            sampling_weights = compute_sampling_weights(bet_probs_betting)
+            
+        else:
+            # role is "alone" or "last" -> Their immediate bet is strictly bound by the bet floor
+            effective_last_bet = max(last_bet, bet_floor - 1)
+            bet_probs_betting = dynamic_probabilities.get_bet_probabilities(game_state, for_betting=True, last_bet=effective_last_bet)
+            sampling_weights = compute_sampling_weights(bet_probs_betting)
 
-        # Check/Bet Evaluation
+        # Check/Bet Evaluation (alone and first can check; last cannot)
         if role in {"alone", "first"} and last_bet is not None and last_bet < check_action_id:
             prob_last_bet_exists = dynamic_probabilities.get_bet_probabilities(game_state, for_betting=False, specific_action_id=last_bet)
             
@@ -119,12 +128,13 @@ class ConservativeAgent(agent.Agent):
             if check:
                 return check_action_id
 
+        # Fallback if there are absolutely zero valid remaining bets
         if not any(sampling_weights):
-            return check_action_id if last_bet is not None else 0
+            return check_action_id if last_bet > -1 else 0
 
         # By this point we've chosen not to check, so we bet
         if role == "first":
-            return min(effective_last_bet + 1, check_action_id)
+            return min(last_bet + 1, check_action_id)
         else: # Alone or last role
             return random.choices(range(len(sampling_weights)), weights=sampling_weights, k=1)[0]
 
@@ -155,7 +165,6 @@ class ConservativeAgent(agent.Agent):
 
             sampled_action = self.determine_action(game_state)
             self.game_manager.play(sampled_action)
-
 
 # Expose determine_action for import
 determine_action = ConservativeAgent.determine_action

--- a/conservative_crawling_ai/agent.py
+++ b/conservative_crawling_ai/agent.py
@@ -35,30 +35,36 @@ class ConservativeCrawlingAgent(agent.Agent):
         last_bet = None
         if game_state.get("history"):
             last_bet = game_state.get("history")[-1]["action_id"]
+        else:
+            last_bet = -1
 
-        # Determine Adjacency Role
-        players = game_state.get("players", [])
+        # Filter eliminated players and determine adjacency role
+        all_players = game_state.get("players", [])
+        active_players = [p for p in all_players if p.get("n_cards", 0) > 0]
         cp_nickname = game_state.get("cp_nickname")
-        cp_index = next((i for i, p in enumerate(players) if p.get("nickname") == cp_nickname), -1)
+        cp_index = next((i for i, p in enumerate(active_players) if p.get("nickname") == cp_nickname), -1)
         
         N = 1
-        if cp_index != -1 and players[cp_index].get("team") is not None:
-            cp_team = players[cp_index].get("team")
+        role = "alone"
+        last_ally_nickname = cp_nickname
+
+        if cp_index != -1 and active_players[cp_index].get("team") is not None:
+            cp_team = active_players[cp_index].get("team")
             
             # Count contiguous allies forward
             forward_allies = 0
-            for i in range(1, len(players)):
-                idx = (cp_index + i) % len(players)
-                if players[idx].get("team") == cp_team:
+            for i in range(1, len(active_players)):
+                idx = (cp_index + i) % len(active_players)
+                if active_players[idx].get("team") == cp_team:
                     forward_allies += 1
                 else:
                     break
                     
             # Count contiguous allies backward
             backward_allies = 0
-            for i in range(1, len(players)):
-                idx = (cp_index - i) % len(players)
-                if players[idx].get("team") == cp_team:
+            for i in range(1, len(active_players)):
+                idx = (cp_index - i) % len(active_players)
+                if active_players[idx].get("team") == cp_team:
                     backward_allies += 1
                 else:
                     break
@@ -67,42 +73,46 @@ class ConservativeCrawlingAgent(agent.Agent):
                 N = 1 + forward_allies + backward_allies
                 if backward_allies == 0:
                     role = "first"
+                    last_ally_idx = (cp_index + forward_allies) % len(active_players)
+                    last_ally_nickname = active_players[last_ally_idx].get("nickname")
                 elif forward_allies == 0:
                     role = "last"
                 else:
                     role = "middle"
-            else:
-                role = "alone"
-        else:
-            role = "alone"
 
+        # Extract Generic Probabilities and Bet Floor
         bet_probs_generic = dynamic_probabilities.get_generic_bet_probabilities(game_state, last_bet=last_bet)
         bet_floor = 0
         for i, prob in enumerate(bet_probs_generic):
             if prob == 1.0:
                 bet_floor = i
-        
-        effective_last_bet = max(last_bet if last_bet is not None else -1, bet_floor - 1)
 
-        # Middle role: just raise by 1 (or check if at max)
+        # Middle role: just raise by 1
         if role == "middle":
-            return min(effective_last_bet + 1, check_action_id)
+            return min(last_bet + 1, check_action_id)
 
-        bet_probs_betting = dynamic_probabilities.get_bet_probabilities(game_state, for_betting=True, last_bet=effective_last_bet)
-        sampling_weights = compute_sampling_weights(bet_probs_betting, bet_probs_generic)
+        # First role: get weights
+        if role == "first":
+            # First ally looks ahead to the situation the last ally will face.
+            effective_last_bet = max(last_bet + N - 1, bet_floor - 1)
+            
+            # Temporarily pretend to be the last ally to calculate using their jokers
+            original_cp_nickname = game_state["cp_nickname"]
+            game_state["cp_nickname"] = last_ally_nickname
+            bet_probs_betting = dynamic_probabilities.get_bet_probabilities(game_state, for_betting=True, last_bet=effective_last_bet)
+            game_state["cp_nickname"] = original_cp_nickname
+            sampling_weights = compute_sampling_weights(bet_probs_betting, bet_probs_generic)
+            
+        else:
+            # role is "alone" or "last" -> Their immediate bet is strictly bound by the bet floor
+            effective_last_bet = max(last_bet, bet_floor - 1)
+            bet_probs_betting = dynamic_probabilities.get_bet_probabilities(game_state, for_betting=True, last_bet=effective_last_bet)
+            sampling_weights = compute_sampling_weights(bet_probs_betting, bet_probs_generic)
 
-        # First role: zero out the weights for the upcoming sets allies will be forced to take
-        if role == "first" and N > 1:
-            start_zero = effective_last_bet + 1
-            end_zero = min(effective_last_bet + 1 + N - 1, len(sampling_weights))
-            for i in range(start_zero, end_zero):
-                sampling_weights[i] = 0.0
-            sampling_weights = normalise(sampling_weights)
-
-        # Check/Bet Evaluation
-        if role in {"alone", "first"} and last_bet is not None and last_bet < check_action_id:
+        # Check/Bet Evaluation (alone and first can check; last cannot)
+        if role in {"alone", "first"} and last_bet > -1 and last_bet < check_action_id:
             prob_last_bet_exists = dynamic_probabilities.get_bet_probabilities(game_state, for_betting=False, specific_action_id=last_bet)
-
+            
             if prob_last_bet_exists == 0:
                 return check_action_id
 
@@ -120,12 +130,13 @@ class ConservativeCrawlingAgent(agent.Agent):
             if check:
                 return check_action_id
 
+        # Fallback if there are absolutely zero valid remaining bets
         if not any(sampling_weights):
-            return check_action_id if last_bet is not None else 0
-            
+            return check_action_id if last_bet > -1 else 0
+
         # By this point we've chosen not to check, so we bet
         if role == "first":
-            return min(effective_last_bet + 1, check_action_id)
+            return min(last_bet + 1, check_action_id)
         else: # Alone or last role
             return random.choices(range(len(sampling_weights)), weights=sampling_weights, k=1)[0]
 

--- a/conservative_crawling_ai/agent.py
+++ b/conservative_crawling_ai/agent.py
@@ -95,7 +95,10 @@ class ConservativeCrawlingAgent(agent.Agent):
         if role == "first":
             # First ally looks ahead to the situation the last ally will face.
             effective_last_bet = max(last_bet + N - 1, bet_floor - 1)
-            
+
+            if effective_last_bet >= check_action_id - 1:
+                return check_action_id if last_bet > -1 else 0
+
             # Temporarily pretend to be the last ally to calculate using their jokers
             original_cp_nickname = game_state["cp_nickname"]
             game_state["cp_nickname"] = last_ally_nickname

--- a/conservative_crawling_ai/agent.py
+++ b/conservative_crawling_ai/agent.py
@@ -36,6 +36,46 @@ class ConservativeCrawlingAgent(agent.Agent):
         if game_state.get("history"):
             last_bet = game_state.get("history")[-1]["action_id"]
 
+        # Determine Adjacency Role
+        players = game_state.get("players", [])
+        cp_nickname = game_state.get("cp_nickname")
+        cp_index = next((i for i, p in enumerate(players) if p.get("nickname") == cp_nickname), -1)
+        
+        N = 1
+        if cp_index != -1 and players[cp_index].get("team") is not None:
+            cp_team = players[cp_index].get("team")
+            
+            # Count contiguous allies forward
+            forward_allies = 0
+            for i in range(1, len(players)):
+                idx = (cp_index + i) % len(players)
+                if players[idx].get("team") == cp_team:
+                    forward_allies += 1
+                else:
+                    break
+                    
+            # Count contiguous allies backward
+            backward_allies = 0
+            for i in range(1, len(players)):
+                idx = (cp_index - i) % len(players)
+                if players[idx].get("team") == cp_team:
+                    backward_allies += 1
+                else:
+                    break
+            
+            if forward_allies > 0 or backward_allies > 0:
+                N = 1 + forward_allies + backward_allies
+                if backward_allies == 0:
+                    role = "first"
+                elif forward_allies == 0:
+                    role = "last"
+                else:
+                    role = "middle"
+            else:
+                role = "alone"
+        else:
+            role = "alone"
+
         bet_probs_generic = dynamic_probabilities.get_generic_bet_probabilities(game_state, last_bet=last_bet)
         bet_floor = 0
         for i, prob in enumerate(bet_probs_generic):
@@ -44,10 +84,23 @@ class ConservativeCrawlingAgent(agent.Agent):
         
         effective_last_bet = max(last_bet if last_bet is not None else -1, bet_floor - 1)
 
+        # Middle role: just raise by 1 (or check if at max)
+        if role == "middle":
+            return min(effective_last_bet + 1, check_action_id)
+
         bet_probs_betting = dynamic_probabilities.get_bet_probabilities(game_state, for_betting=True, last_bet=effective_last_bet)
         sampling_weights = compute_sampling_weights(bet_probs_betting, bet_probs_generic)
 
-        if last_bet is not None and last_bet < check_action_id:
+        # First role: zero out the weights for the upcoming sets allies will be forced to take
+        if role == "first" and N > 1:
+            start_zero = effective_last_bet + 1
+            end_zero = min(effective_last_bet + 1 + N - 1, len(sampling_weights))
+            for i in range(start_zero, end_zero):
+                sampling_weights[i] = 0.0
+            sampling_weights = normalise(sampling_weights)
+
+        # Check/Bet Evaluation
+        if role in {"alone", "first"} and last_bet is not None and last_bet < check_action_id:
             prob_last_bet_exists = dynamic_probabilities.get_bet_probabilities(game_state, for_betting=False, specific_action_id=last_bet)
 
             if prob_last_bet_exists == 0:
@@ -70,8 +123,11 @@ class ConservativeCrawlingAgent(agent.Agent):
         if not any(sampling_weights):
             return check_action_id if last_bet is not None else 0
             
-        sampled_action = random.choices(range(len(sampling_weights)), weights=sampling_weights, k=1)[0]
-        return sampled_action
+        # By this point we've chosen not to check, so we bet
+        if role == "first":
+            return min(effective_last_bet + 1, check_action_id)
+        else: # Alone or last role
+            return random.choices(range(len(sampling_weights)), weights=sampling_weights, k=1)[0]
 
     def run(self):
         """

--- a/shared/probabilities/dynamic_probabilities.py
+++ b/shared/probabilities/dynamic_probabilities.py
@@ -173,11 +173,13 @@ def _rebuild_rules(rules_key: Tuple[int, int, int]) -> dict:
 
 class ProbContext(NamedTuple):
     hand_cards: Tuple[Tuple[int, int], ...]
+    allied_cards: Tuple[Tuple[int, int], ...]
     common_cards: Tuple[Tuple[int, int], ...]
     known_cards: Tuple[Tuple[int, int], ...]
     value_counts: Tuple[int, ...]
     colour_counts: Tuple[int, ...]
     my_jokers: int
+    allied_jokers: int
     common_jokers: int
     deck_size: int
     total_jokers: int
@@ -185,53 +187,50 @@ class ProbContext(NamedTuple):
 
 
 @lru_cache(maxsize=50000)
-def _prepare_prob_context(hand_key: Tuple[Tuple[int, int], ...], common_key: Tuple[Tuple[int, int], ...], rules_key: Tuple[int, int, int]) -> ProbContext:
+def _prepare_prob_context(
+    hand_key: Tuple[Tuple[int, int], ...], 
+    allied_key: Tuple[Tuple[int, int], ...], 
+    common_key: Tuple[Tuple[int, int], ...], 
+    rules_key: Tuple[int, int, int]
+) -> ProbContext:
     deck_size, total_jokers, total_blanks = rules_key
     hand_cards = tuple((int(v), int(c)) for v, c in hand_key)
+    allied_cards = tuple((int(v), int(c)) for v, c in allied_key)
     common_cards = tuple((int(v), int(c)) for v, c in common_key)
-    known_cards = hand_cards + common_cards
+    known_cards = hand_cards + allied_cards + common_cards
 
     if deck_size % 4 != 0:
         raise ValueError(f"Deck size {deck_size} unsupported (must be divisible by 4).")
     num_values = deck_size // 4
     value_counts = [0] * num_values
     colour_counts = [0] * 4
-    my_jokers = 0
-    common_jokers = 0
 
-    for value, colour in hand_cards:
+    my_jokers = sum(1 for v, c in hand_cards if v == -1)
+    allied_jokers = sum(1 for v, c in allied_cards if v == -1)
+    common_jokers = sum(1 for v, c in common_cards if v == -1)
+
+    for value, colour in known_cards:
         if value >= 0:
             if value >= num_values:
                 raise ValueError(f"Card value {value} exceeds deck bounds for deck size {deck_size}.")
             value_counts[value] += 1
             if colour >= 0:
                 colour_counts[colour] += 1
-        elif value == -1:
-            my_jokers += 1
-
-    for value, colour in common_cards:
-        if value >= 0:
-            if value >= num_values:
-                raise ValueError(f"Card value {value} exceeds deck bounds for deck size {deck_size}.")
-            value_counts[value] += 1
-            if colour >= 0:
-                colour_counts[colour] += 1
-        elif value == -1:
-            common_jokers += 1
 
     return ProbContext(
         hand_cards=hand_cards,
+        allied_cards=allied_cards,
         common_cards=common_cards,
         known_cards=known_cards,
         value_counts=tuple(value_counts),
         colour_counts=tuple(colour_counts),
         my_jokers=my_jokers,
+        allied_jokers=allied_jokers,
         common_jokers=common_jokers,
         deck_size=int(deck_size),
         total_jokers=int(total_jokers),
         total_blanks=int(total_blanks),
     )
-
 
 def _calculate_prob_with_context(action_id: int, ctx: ProbContext, unknown_cards_num: int, for_betting: bool) -> float:
     rules = {"deck_size": ctx.deck_size, "jokers": ctx.total_jokers, "blanks": ctx.total_blanks}
@@ -242,8 +241,9 @@ def _calculate_prob_with_context(action_id: int, ctx: ProbContext, unknown_cards
     value_counts = list(ctx.value_counts)
     colour_counts = list(ctx.colour_counts)
     my_jokers = ctx.my_jokers
+    allied_jokers = ctx.allied_jokers
     common_jokers = ctx.common_jokers
-    known_jokers = my_jokers + common_jokers
+    known_jokers = my_jokers + allied_jokers + common_jokers
 
     jokers_in_play = my_jokers + common_jokers if for_betting else common_jokers
 
@@ -344,11 +344,13 @@ def _calculate_prob_with_context(action_id: int, ctx: ProbContext, unknown_cards
         
         return _calculate_prob_simple_set(needed, cards_of_value_in_deck, jokers_in_deck, other_cards_in_deck, unknown_cards_num)
 
-def _calculate_prob_no_cache(action_id, hand, common_hand, unknown_cards_num, rules, for_betting):
+def _calculate_prob_no_cache(action_id, hand, allied_hand, common_hand, unknown_cards_num, rules, for_betting):
     hand_key = _normalize_cards(hand)
+    allied_key = _normalize_cards(allied_hand)
     common_key = _normalize_cards(common_hand)
     rules_key = _normalize_rules(rules)
-    ctx = _prepare_prob_context(hand_key, common_key, rules_key)
+    ctx = _prepare_prob_context(hand_key, allied_key, common_key, rules_key)
+    
     return _calculate_prob_with_context(
         int(action_id),
         ctx,
@@ -357,26 +359,27 @@ def _calculate_prob_no_cache(action_id, hand, common_hand, unknown_cards_num, ru
     )
 
 
-def calculate_prob(action_id, hand, common_hand, unknown_cards_num, rules, for_betting):
+def calculate_prob(action_id, hand, allied_hand, common_hand, unknown_cards_num, rules, for_betting):
     return _calculate_prob_no_cache(
         action_id,
         hand,
+        allied_hand,
         common_hand,
         unknown_cards_num,
         rules,
         for_betting,
     )
 
-
 @lru_cache(maxsize=20000)
 def _probability_vector_cached(
     hand_key: Tuple[Tuple[int, int], ...],
+    allied_key: Tuple[Tuple[int, int], ...],
     common_key: Tuple[Tuple[int, int], ...],
     rules_key: Tuple[int, int, int],
     unknown_cards_num: int,
     for_betting_flag: bool,
 ) -> Tuple[float, ...]:
-    ctx = _prepare_prob_context(hand_key, common_key, rules_key)
+    ctx = _prepare_prob_context(hand_key, allied_key, common_key, rules_key)
     game_rules = GameRules(rules_key[0])
     vector = [
         _calculate_prob_with_context(action_id, ctx, unknown_cards_num, for_betting_flag)
@@ -392,21 +395,30 @@ def get_bet_probabilities(game_state, for_betting=False, last_bet=None, specific
     players = game_state.get("players", [])
     agent_nickname = game_state["cp_nickname"]
 
-    matching_hands = [h for h in game_state.get("hands", []) if h.get("nickname") == agent_nickname]
-    if not matching_hands:
-        return 0.0 if specific_action_id is not None else [0.0] * (game_rules.num_actions - 1)
-    hand = [(card["value"], card["colour"]) for card in matching_hands[0]["hand"]]
+    agent_team = next((p.get("team") for p in players if p.get("nickname") == agent_nickname), None)
+    allies = {p.get("nickname") for p in players if p.get("team") == agent_team and p.get("nickname") != agent_nickname} if agent_team is not None else set()
 
-    others_card_num = sum(p.get("n_cards", 0) for p in players if p.get("nickname") != agent_nickname)
+    hands = game_state.get("hands", [])
+    hand, allied_hand = [], []
+    for h in hands:
+        if h.get("nickname") == agent_nickname:
+            hand = [(card["value"], card["colour"]) for card in h.get("hand", [])]
+        elif h.get("nickname") in allies:
+            allied_hand.extend([(card["value"], card["colour"]) for card in h.get("hand", [])])
+
+    # Unseen cards belong only to opponents
+    others_card_num = sum(p.get("n_cards", 0) for p in players if p.get("nickname") not in allies and p.get("nickname") != agent_nickname)
     common_hand = [(card["value"], card["colour"]) for card in game_state.get("common_hand", [])]
 
     hand_key = _normalize_cards(hand)
+    allied_key = _normalize_cards(allied_hand)
     common_key = _normalize_cards(common_hand)
     rules_key = _normalize_rules(rules)
 
     vector = list(
         _probability_vector_cached(
             hand_key,
+            allied_key,
             common_key,
             rules_key,
             int(others_card_num),
@@ -433,15 +445,17 @@ def get_generic_bet_probabilities(game_state, last_bet=None):
     others_card_num = sum(p.get("n_cards", 0) for p in players if p.get("nickname") != agent_nickname)
     
     common_hand = [(card["value"], card["colour"]) for card in game_state.get("common_hand", [])]
-    unknown_cards_num = my_card_num + others_card_num
+    unknown_cards_num = sum(p.get("n_cards", 0) for p in players)
 
     hand_key: Tuple[Tuple[int, int], ...] = ()
+    allied_key: Tuple[Tuple[int, int], ...] = ()
     common_key = _normalize_cards(common_hand)
     rules_key = _normalize_rules(rules)
 
     vector = list(
         _probability_vector_cached(
             hand_key,
+            allied_key,
             common_key,
             rules_key,
             int(unknown_cards_num),


### PR DESCRIPTION
Implements https://github.com/Blef-team/blef_game_engine/pull/220 for conservative AIs.

They now take allies' hands into account (but keeping in mind that they cannot use allies' jokers) and bet/check in a way that's mindful of whether they're adjacent to an ally