### PR TITLE
Phase 0: Eval ladder + backfill + dashboard

### DIFF
--- a/tests/test_eval_ladder.py
+++ b/tests/test_eval_ladder.py
@@ -1,0 +1,81 @@
+"""Smoke tests for tools.eval_ladder.
+
+These tests run very small games (n_games=4) against random and conservative
+opponents to verify the harness wires up correctly.
+"""
+
+import os
+import unittest
+import torch
+
+from tools.eval_ladder import (
+    RandomOpponent,
+    ConservativeOpponent,
+    CFROpponent,
+    head_to_head,
+    build_opponents,
+    MatchResult,
+)
+from nfsp_ai.agent import NFSPAgent, NFSPConfig
+from nfsp_ai.nfsp_run_local import MyEnv
+
+
+def _fresh_agent(deck_size: int = 24, n_players: int = 2):
+    env = MyEnv(n_agents=n_players, deck_size=deck_size, max_cards=2)
+    obs, mask, _pid = env.reset()
+    obs_dim = int(obs.shape[-1])
+    act_dim = int(mask.shape[-1])
+    cfg = NFSPConfig(rl_capacity=1, sl_capacity=1)
+    agent = NFSPAgent(obs_dim, act_dim, device=torch.device("cpu"), cfg=cfg)
+    return agent
+
+
+class EvalLadderSmokeTest(unittest.TestCase):
+    def test_random_opponent_against_random_learner(self):
+        agent = _fresh_agent()
+        opp = RandomOpponent()
+        r = head_to_head(
+            agent, opp,
+            n_games=4, deck_size=24, n_players=2, max_cards=2, seed=123,
+        )
+        self.assertIsInstance(r, MatchResult)
+        self.assertEqual(r.opponent, "random")
+        self.assertEqual(r.n_games, 4)
+        self.assertEqual(r.wins + r.losses + r.draws, 4)
+        self.assertGreaterEqual(r.mean_game_length_actions, 1.0)
+        self.assertGreater(r.elapsed_seconds, 0.0)
+
+    def test_conservative_opponent_runs(self):
+        agent = _fresh_agent()
+        opp = ConservativeOpponent()
+        r = head_to_head(
+            agent, opp,
+            n_games=2, deck_size=24, n_players=2, max_cards=1, seed=7,
+        )
+        self.assertEqual(r.opponent, "conservative")
+        self.assertEqual(r.wins + r.losses + r.draws, 2)
+
+    def test_cfr_unavailable_when_outputs_missing(self):
+        # cfr_ai/outputs/ should not exist locally for this PR's test env.
+        opp = CFROpponent()
+        # Either truly unavailable, or skip if a developer has populated the dir.
+        if not opp.available():
+            self.assertFalse(opp.available())
+            built = build_opponents("cfr", 1, 1)
+            self.assertEqual(built, [])
+        else:
+            self.skipTest("CFR strategies present locally; availability test skipped")
+
+    def test_winrate_ci_bounds(self):
+        agent = _fresh_agent()
+        r = head_to_head(
+            agent, RandomOpponent(),
+            n_games=8, deck_size=24, n_players=2, max_cards=1, seed=1,
+        )
+        self.assertGreaterEqual(r.winrate, 0.0)
+        self.assertLessEqual(r.winrate, 1.0)
+        self.assertGreaterEqual(r.winrate_ci_95, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,78 @@
+# tools/
+
+Operational tooling for evaluating, comparing, and visualising NFSP runs.
+
+## Eval ladder — head-to-head metric harness
+
+`tools/eval_ladder.py` plays a checkpointed NFSP agent against a fixed opponent
+and reports winrate / mean reward / 95% CI. Four opponent types in the "metric
+ladder," ordered floor → strong:
+
+| Opponent       | Rationale                                                 |
+| -------------- | --------------------------------------------------------- |
+| `random`       | Floor. Anything weaker than this is broken.               |
+| `conservative` | Current default baseline (rule-based).                    |
+| `cfr`          | Tabular CFR, near-Nash at low cardinality. Requires the strategy CSVs under `cfr_ai/outputs/` plus a top-level `metadata.csv`. Skipped automatically if missing. |
+| `snapshot`     | Another NFSP checkpoint (for self-improvement signal).    |
+
+Run from the repository root:
+
+```sh
+python -m tools.eval_ladder \
+  --checkpoint nfsp_blef_<timestamp>_<N>M.pt \
+  --opponents random,conservative \
+  --n-games 200 \
+  --deck-size 24 --n-players 2 --max-cards 11
+```
+
+The `--deck-size`, `--jokers`, `--blanks`, `--common-cards` flags must match the
+configuration the checkpoint was trained with. Mismatched rules raise a clear
+`ValueError` rather than producing nonsense (the trained network's input shape
+won't match the env's observation shape).
+
+## Backfill — run the ladder over historical checkpoints
+
+`tools/backfill_eval.py` iterates a glob of `.pt` checkpoints and writes one
+`eval_results/<checkpoint-stem>/ladder.csv` per checkpoint. Resumable: skips
+checkpoints whose `ladder.csv` already exists.
+
+```sh
+python -m tools.backfill_eval \
+  --pattern 'nfsp_blef_*_*M.pt' \
+  --opponents random,conservative \
+  --n-games 200 \
+  --deck-size 24 --n-players 2 --max-cards 11
+```
+
+## Optional dependencies
+
+The dashboard requires `streamlit` and `pandas`. Install with:
+
+```sh
+pip install -r tools/requirements.txt
+```
+
+The eval ladder and backfill scripts use only stdlib + project deps; no extra installs.
+
+## Dashboard — Streamlit live view
+
+`tools/run_dashboard.py` is a Streamlit app that auto-discovers run dirs under
+`runs/` and ladder backfills under `eval_results/`. Multi-select runs to overlay
+their training metrics; multi-select backfills to compare ladder outcomes
+across checkpoints.
+
+```sh
+streamlit run tools/run_dashboard.py
+```
+
+The browser tab stays open; new runs appear automatically as their dirs
+materialise. Auto-refresh interval is configurable in the sidebar.
+
+Conventions the dashboard expects:
+
+- Runs:        `runs/<YYYYMMDD-HHMMSS>__<experiment-name>/metrics.csv`
+- Backfills:   `eval_results/<checkpoint-stem>/ladder.csv`
+
+A future PR will rewire `nfsp_run_local.py` to write into the timestamped
+`runs/` convention by default. For now, the dashboard works on backfilled
+results out of the box.

--- a/tools/backfill_eval.py
+++ b/tools/backfill_eval.py
@@ -1,0 +1,132 @@
+"""
+Backfill eval-ladder results across historical NFSP checkpoints.
+
+Given a glob of .pt files (e.g. `nfsp_blef_*_*M.pt` saved at million-step
+boundaries), runs `tools.eval_ladder` for each checkpoint and writes one
+`eval_results/<checkpoint-stem>/ladder.csv` per checkpoint. Resumable: skips
+checkpoints whose ladder.csv already exists.
+
+Run from the repository root:
+
+  python -m tools.backfill_eval \\
+    --pattern 'nfsp_blef_*_*M.pt' \\
+    --opponents random,conservative \\
+    --n-games 200 \\
+    --deck-size 24 --n-players 2 --max-cards 11
+
+Inference-only exports (`*-inference.pt`) are skipped by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import sys
+import time
+from typing import List, Optional
+
+from tools.eval_ladder import (
+    build_opponents,
+    load_learner,
+    run_ladder,
+    write_results_csv,
+)
+
+DEFAULT_OUTPUT_ROOT = "eval_results"
+
+
+def _checkpoint_stem(path: str) -> str:
+    base = os.path.basename(path)
+    if base.endswith(".pt"):
+        base = base[:-3]
+    return base
+
+
+def _iter_checkpoints(pattern: str, exclude_inference: bool = True) -> List[str]:
+    paths = sorted(glob.glob(pattern))
+    if exclude_inference:
+        paths = [p for p in paths if "-inference" not in os.path.basename(p)]
+    return paths
+
+
+def _ladder_path_for(ckpt: str, output_root: str = DEFAULT_OUTPUT_ROOT) -> str:
+    stem = _checkpoint_stem(ckpt)
+    return os.path.join(output_root, stem, "ladder.csv")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--pattern", required=True, help="Glob for checkpoint .pt files (e.g. 'nfsp_blef_*_*M.pt').")
+    p.add_argument(
+        "--opponents",
+        default="random,conservative",
+        help="Comma-separated subset of {random, conservative, cfr, snapshot}.",
+    )
+    p.add_argument("--snapshot-paths", default="", help="Comma-separated checkpoint paths if opponents includes 'snapshot'.")
+    p.add_argument("--n-games", type=int, default=200)
+    p.add_argument("--deck-size", type=int, default=24, choices=[24, 32])
+    p.add_argument("--n-players", type=int, default=2)
+    p.add_argument("--max-cards", type=int, default=11)
+    p.add_argument("--jokers", type=int, default=0)
+    p.add_argument("--blanks", type=int, default=0)
+    p.add_argument("--common-cards", type=int, default=0)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--output-root", default=DEFAULT_OUTPUT_ROOT)
+    p.add_argument("--force", action="store_true", help="Re-run even if ladder.csv already exists.")
+    p.add_argument("--include-inference", action="store_true", help="Include *-inference.pt exports.")
+    args = p.parse_args(argv)
+
+    checkpoints = _iter_checkpoints(args.pattern, exclude_inference=not args.include_inference)
+    if not checkpoints:
+        print(f"No checkpoints matched pattern {args.pattern!r}", file=sys.stderr)
+        return 2
+
+    snap_paths = [p.strip() for p in args.snapshot_paths.split(",") if p.strip()]
+
+    n_done = n_skipped = n_failed = 0
+    t0 = time.time()
+    for ckpt in checkpoints:
+        ladder_path = _ladder_path_for(ckpt, args.output_root)
+        if os.path.exists(ladder_path) and not args.force:
+            n_skipped += 1
+            print(f"[skip] {ckpt}: ladder.csv already exists", file=sys.stderr)
+            continue
+        try:
+            learner = load_learner(ckpt)
+            opponents = build_opponents(
+                args.opponents, learner.obs_dim, learner.act_dim,
+                snapshot_paths=snap_paths,
+            )
+            if not opponents:
+                print(f"[fail] {ckpt}: no opponents could be constructed", file=sys.stderr)
+                n_failed += 1
+                continue
+            results = run_ladder(
+                learner, opponents,
+                n_games=args.n_games,
+                deck_size=args.deck_size,
+                n_players=args.n_players,
+                max_cards=args.max_cards,
+                jokers=args.jokers,
+                blanks=args.blanks,
+                common_cards=args.common_cards,
+                seed=args.seed,
+            )
+            write_results_csv(ladder_path, results)
+            n_done += 1
+            print(f"[done] {ckpt} -> {ladder_path}", file=sys.stderr)
+        except Exception as exc:  # noqa: BLE001
+            n_failed += 1
+            print(f"[fail] {ckpt}: {exc!r}", file=sys.stderr)
+
+    elapsed = time.time() - t0
+    print(
+        f"Backfill: {n_done} processed, {n_skipped} skipped, {n_failed} failed in {elapsed:.1f}s",
+        file=sys.stderr,
+    )
+    return 0 if n_failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/eval_ladder.py
+++ b/tools/eval_ladder.py
@@ -1,0 +1,485 @@
+"""
+Head-to-head evaluation harness for the NFSP Blef agent.
+
+Plays a learner agent against a fixed opponent across N games and reports
+winrate, mean reward, and 95% CI from the learner's perspective. Supports
+four opponent types (the "metric ladder"):
+
+  random      : uniform random over legal actions (floor)
+  conservative: rule-based ConservativeAgent (current default baseline)
+  cfr         : tabular CFR strategy (strong baseline; requires CFR CSVs
+                under cfr_ai/outputs/ — see cfr_ai/agent.py:28)
+  snapshot    : another NFSP checkpoint loaded for opposing play
+                (self-improvement signal)
+
+Run as a module from the repository root:
+
+  python -m tools.eval_ladder \\
+    --checkpoint runs/<id>/checkpoints/nfsp_blef.pt \\
+    --opponents random,conservative \\
+    --n-games 200 \\
+    --deck-size 24 --n-players 2 --max-cards 11
+
+Writes a CSV of one row per (opponent, config) to --output (default stdout).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import os
+import random
+import sys
+import time
+from dataclasses import dataclass, field, asdict
+from typing import Callable, Dict, List, Optional, Tuple
+
+import torch
+
+# Project imports — assume repo root is on sys.path (run as `python -m tools.eval_ladder`).
+from conservative_ai.agent import ConservativeAgent
+from nfsp_ai.agent import NFSPAgent, NFSPConfig
+from nfsp_ai.nfsp_run_local import MyEnv, _compute_obs_dim
+
+
+# --------------------------------------------------------------------------
+# Opponents
+# --------------------------------------------------------------------------
+
+class Opponent:
+    """Minimal interface: pick a legal action from the current env state."""
+
+    name: str = "abstract"
+
+    def act(self, game_state: Dict, obs: torch.Tensor, mask: torch.Tensor) -> int:
+        raise NotImplementedError
+
+    def reset(self) -> None:
+        """Optional per-game reset hook."""
+        pass
+
+
+def _legal_or_random(action: Optional[int], mask: torch.Tensor) -> int:
+    """Validate `action` against `mask`; fall back to a random legal action."""
+    legal = mask.nonzero(as_tuple=False).view(-1).tolist()
+    if action is None or not legal:
+        return int(legal[0]) if legal else 0
+    a = int(action)
+    if 0 <= a < mask.shape[-1] and mask[a] > 0:
+        return a
+    return int(random.choice(legal)) if legal else 0
+
+
+class RandomOpponent(Opponent):
+    name = "random"
+
+    def act(self, game_state, obs, mask):
+        legal = mask.nonzero(as_tuple=False).view(-1).tolist()
+        return int(random.choice(legal)) if legal else 0
+
+
+class ConservativeOpponent(Opponent):
+    name = "conservative"
+
+    def act(self, game_state, obs, mask):
+        try:
+            a = ConservativeAgent.determine_action(game_state)
+        except Exception:
+            a = None
+        return _legal_or_random(a, mask)
+
+
+class CFROpponent(Opponent):
+    """
+    Loads CFR strategy CSVs lazily. If the strategy files aren't present,
+    `available()` returns False and the ladder skips this opponent.
+
+    See cfr_ai/agent.py for the CSV layout. The CSVs live under
+    cfr_ai/outputs/<hand_sizes>/<key0>/<key1>.csv plus a top-level metadata.csv.
+    """
+
+    name = "cfr"
+
+    def __init__(self):
+        self._available = self._probe()
+
+    def available(self) -> bool:
+        return self._available
+
+    @staticmethod
+    def _probe() -> bool:
+        # CFR's determine_action requires both metadata.csv and an outputs/ dir
+        # populated for the configs we'll ask about. Cheapest probe: check that
+        # cfr_ai/outputs exists and is non-empty, AND metadata.csv exists.
+        if not os.path.exists("metadata.csv"):
+            return False
+        outputs = "cfr_ai/outputs"
+        if not os.path.isdir(outputs):
+            return False
+        try:
+            return any(os.scandir(outputs))
+        except OSError:
+            return False
+
+    def act(self, game_state, obs, mask):
+        if not self._available:
+            return _legal_or_random(None, mask)
+        try:
+            from cfr_ai.agent import determine_action as cfr_determine
+            a = cfr_determine(game_state)
+        except (FileNotFoundError, KeyError, IndexError, ValueError, Exception):
+            a = None
+        return _legal_or_random(a, mask)
+
+
+class SnapshotOpponent(Opponent):
+    """Loads an NFSP checkpoint for inference-only opposition."""
+
+    def __init__(self, checkpoint_path: str, obs_dim: int, act_dim: int, device: Optional[torch.device] = None, label: Optional[str] = None):
+        self.checkpoint_path = checkpoint_path
+        self.name = label or f"snapshot:{os.path.basename(checkpoint_path)}"
+        self.device = device or torch.device("cpu")
+        # Tiny buffers — we don't train, but NFSPAgent's __init__ allocates them.
+        cfg = NFSPConfig(rl_capacity=1, sl_capacity=1)
+        self.agent = NFSPAgent(obs_dim, act_dim, device=self.device, cfg=cfg)
+        ckpt = torch.load(checkpoint_path, map_location=self.device, weights_only=False)
+        # Use the inference-relevant subset; tolerate both full and exported payloads.
+        if "q" in ckpt:
+            self.agent.q.load_state_dict(ckpt["q"])
+        if "pi" in ckpt:
+            self.agent.pi.load_state_dict(ckpt["pi"])
+
+    def act(self, game_state, obs, mask):
+        return self.agent.select_action(obs, mask, use_average_policy=True, greedy=True)
+
+
+# --------------------------------------------------------------------------
+# Match runner
+# --------------------------------------------------------------------------
+
+@dataclass
+class MatchResult:
+    opponent: str
+    config: str
+    n_games: int
+    wins: int
+    losses: int
+    draws: int
+    winrate: float
+    winrate_ci_95: float
+    mean_reward: float
+    mean_game_length_actions: float
+    elapsed_seconds: float
+    metadata: Dict = field(default_factory=dict)
+
+
+def _winrate_ci_95(wins: int, n: int) -> float:
+    if n <= 0:
+        return 0.0
+    p = wins / n
+    return 1.96 * math.sqrt(p * (1.0 - p) / n)
+
+
+def head_to_head(
+    learner: NFSPAgent,
+    opponent: Opponent,
+    *,
+    n_games: int,
+    deck_size: int = 24,
+    n_players: int = 2,
+    max_cards: int = 11,
+    jokers: int = 0,
+    blanks: int = 0,
+    common_cards: int = 0,
+    seed: Optional[int] = None,
+    greedy_learner: bool = True,
+    use_average_policy: bool = True,
+) -> MatchResult:
+    """Run `n_games` between learner and opponent. Learner plays the env's
+    randomly-chosen reference seat each game; opponent plays all other seats.
+
+    Reward is +1 if the learner wins the round, -1 if it loses (env's natural
+    actor-perspective reward). Aggregated across rounds within a game; per-game
+    "win" defined as cumulative reward > 0.
+    """
+    if seed is not None:
+        random.seed(seed)
+        torch.manual_seed(seed)
+
+    env = MyEnv(
+        n_agents=n_players,
+        max_cards=max_cards,
+        deck_size=deck_size,
+        jokers=jokers,
+        blanks=blanks,
+        common_cards=common_cards,
+    )
+
+    # Sanity: env obs_dim must match the learner's expected input.
+    # Learners trained with different rules / embeddings have different
+    # obs_dims that aren't recorded in the checkpoint, so configuration
+    # has to be supplied at eval time. Catch the mismatch with a clear
+    # error rather than letting torch raise "mat1 and mat2 shapes ...".
+    probe_obs, _probe_mask, _ = env.reset()
+    if int(probe_obs.shape[-1]) != int(learner.obs_dim):
+        raise ValueError(
+            f"Env obs_dim {int(probe_obs.shape[-1])} does not match learner obs_dim "
+            f"{int(learner.obs_dim)} for checkpoint. The checkpoint was trained with "
+            f"different rules (deck_size, jokers, blanks, common_cards) or with embeddings "
+            f"enabled. Re-run with matching --deck-size / --jokers / --blanks / --common-cards "
+            f"flags."
+        )
+    # Reset env so the first game starts cleanly.
+    env = MyEnv(
+        n_agents=n_players,
+        max_cards=max_cards,
+        deck_size=deck_size,
+        jokers=jokers,
+        blanks=blanks,
+        common_cards=common_cards,
+    )
+
+    wins = losses = draws = 0
+    total_actions = 0
+    t0 = time.time()
+
+    for _ in range(n_games):
+        opponent.reset()
+        obs, mask, _pid = env.reset()
+        cumulative_reward = 0.0
+        actions_this_game = 0
+        done = False
+
+        while not done:
+            cp = env.game.get("cp_nickname")
+            ref = env._ref_nick
+            game_state = env.game
+            if cp == ref:
+                action = learner.select_action(
+                    obs, mask,
+                    use_average_policy=use_average_policy,
+                    greedy=greedy_learner,
+                )
+                action = _legal_or_random(action, mask)
+            else:
+                action = opponent.act(game_state, obs, mask)
+                action = _legal_or_random(action, mask)
+
+            obs, mask, reward, done, _info = env.step(int(action))
+            actions_this_game += 1
+            cumulative_reward += float(reward)
+
+        total_actions += actions_this_game
+        if cumulative_reward > 0:
+            wins += 1
+        elif cumulative_reward < 0:
+            losses += 1
+        else:
+            draws += 1
+
+    elapsed = time.time() - t0
+    settled = wins + losses
+    winrate = wins / settled if settled else 0.0
+    return MatchResult(
+        opponent=opponent.name,
+        config=f"deck{deck_size}_p{n_players}_mc{max_cards}_j{jokers}_b{blanks}_cc{common_cards}",
+        n_games=n_games,
+        wins=wins,
+        losses=losses,
+        draws=draws,
+        winrate=winrate,
+        winrate_ci_95=_winrate_ci_95(wins, settled),
+        mean_reward=(wins - losses) / max(1, n_games),
+        mean_game_length_actions=total_actions / max(1, n_games),
+        elapsed_seconds=elapsed,
+        metadata={"seed": seed, "greedy": greedy_learner},
+    )
+
+
+# --------------------------------------------------------------------------
+# Loading the learner
+# --------------------------------------------------------------------------
+
+def _detect_dims_from_checkpoint(ckpt_path: str) -> Tuple[int, int]:
+    """Inspect a saved NFSP checkpoint and return (obs_dim, act_dim)."""
+    state = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    pi = state.get("pi") or state.get("q") or {}
+    # PolicyNet first linear weight has shape [hidden, obs_dim]; output head [act_dim, hidden].
+    weights = list(pi.values()) if isinstance(pi, dict) else []
+    obs_dim = act_dim = None
+    for k, v in (pi.items() if isinstance(pi, dict) else []):
+        if k.endswith("enc.0.weight") or k.endswith("net.0.weight"):
+            obs_dim = int(v.shape[1])
+        if k.endswith("pi.weight") or (k.endswith("net.4.weight") and act_dim is None):
+            act_dim = int(v.shape[0])
+    if obs_dim is None or act_dim is None:
+        # Fallback: use the explicit "obs_dim"/"act_dim" if exported-inference shape
+        obs_dim = obs_dim or int(state.get("obs_dim") or 0)
+        act_dim = act_dim or int(state.get("act_dim") or 0)
+    if not (obs_dim and act_dim):
+        raise ValueError(f"Could not infer obs_dim/act_dim from checkpoint {ckpt_path}")
+    return obs_dim, act_dim
+
+
+def load_learner(checkpoint_path: str, device: Optional[torch.device] = None) -> NFSPAgent:
+    device = device or torch.device("cpu")
+    obs_dim, act_dim = _detect_dims_from_checkpoint(checkpoint_path)
+    cfg = NFSPConfig(rl_capacity=1, sl_capacity=1)  # don't allocate large buffers for inference
+    agent = NFSPAgent(obs_dim, act_dim, device=device, cfg=cfg)
+    state = torch.load(checkpoint_path, map_location=device, weights_only=False)
+    if "q" in state:
+        agent.q.load_state_dict(state["q"])
+    if "pi" in state:
+        agent.pi.load_state_dict(state["pi"])
+    return agent
+
+
+# --------------------------------------------------------------------------
+# Ladder driver
+# --------------------------------------------------------------------------
+
+OPPONENT_REGISTRY: Dict[str, Callable[[int, int], Opponent]] = {
+    "random": lambda obs_dim, act_dim: RandomOpponent(),
+    "conservative": lambda obs_dim, act_dim: ConservativeOpponent(),
+    "cfr": lambda obs_dim, act_dim: CFROpponent(),
+}
+
+
+def build_opponents(
+    spec: str,
+    obs_dim: int,
+    act_dim: int,
+    snapshot_paths: Optional[List[str]] = None,
+) -> List[Opponent]:
+    out: List[Opponent] = []
+    for name in (spec.split(",") if spec else []):
+        name = name.strip()
+        if not name:
+            continue
+        if name == "snapshot":
+            for p in (snapshot_paths or []):
+                out.append(SnapshotOpponent(p, obs_dim, act_dim))
+            continue
+        builder = OPPONENT_REGISTRY.get(name)
+        if not builder:
+            raise ValueError(f"Unknown opponent: {name}")
+        opp = builder(obs_dim, act_dim)
+        if isinstance(opp, CFROpponent) and not opp.available():
+            print(f"[warn] CFR opponent unavailable (cfr_ai/outputs/ missing or empty); skipping", file=sys.stderr)
+            continue
+        out.append(opp)
+    return out
+
+
+def run_ladder(
+    learner: NFSPAgent,
+    opponents: List[Opponent],
+    *,
+    n_games: int,
+    deck_size: int = 24,
+    n_players: int = 2,
+    max_cards: int = 11,
+    jokers: int = 0,
+    blanks: int = 0,
+    common_cards: int = 0,
+    seed: Optional[int] = None,
+) -> List[MatchResult]:
+    results: List[MatchResult] = []
+    for opp in opponents:
+        r = head_to_head(
+            learner, opp,
+            n_games=n_games,
+            deck_size=deck_size,
+            n_players=n_players,
+            max_cards=max_cards,
+            jokers=jokers,
+            blanks=blanks,
+            common_cards=common_cards,
+            seed=seed,
+        )
+        results.append(r)
+    return results
+
+
+def write_results_csv(path: str, results: List[MatchResult]) -> None:
+    fieldnames = [
+        "opponent", "config", "n_games", "wins", "losses", "draws",
+        "winrate", "winrate_ci_95", "mean_reward",
+        "mean_game_length_actions", "elapsed_seconds",
+    ]
+    new_file = not os.path.exists(path)
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "a" if not new_file else "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        if new_file:
+            w.writeheader()
+        for r in results:
+            row = {k: getattr(r, k) for k in fieldnames}
+            w.writerow(row)
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+def _build_argparser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--checkpoint", required=True, help="Path to .pt NFSP checkpoint.")
+    p.add_argument(
+        "--opponents",
+        default="random,conservative",
+        help="Comma-separated subset of {random, conservative, cfr, snapshot}.",
+    )
+    p.add_argument("--snapshot-paths", default="", help="Comma-separated checkpoint paths (used when opponents includes 'snapshot').")
+    p.add_argument("--n-games", type=int, default=200)
+    p.add_argument("--deck-size", type=int, default=24, choices=[24, 32])
+    p.add_argument("--n-players", type=int, default=2)
+    p.add_argument("--max-cards", type=int, default=11)
+    p.add_argument("--jokers", type=int, default=0)
+    p.add_argument("--blanks", type=int, default=0)
+    p.add_argument("--common-cards", type=int, default=0)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--output", default="", help="CSV output path. Empty = stdout.")
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _build_argparser().parse_args(argv)
+    learner = load_learner(args.checkpoint)
+    snap_paths = [p for p in args.snapshot_paths.split(",") if p.strip()]
+    opponents = build_opponents(args.opponents, learner.obs_dim, learner.act_dim, snapshot_paths=snap_paths)
+    if not opponents:
+        print("No opponents constructed — exiting.", file=sys.stderr)
+        return 2
+    results = run_ladder(
+        learner, opponents,
+        n_games=args.n_games,
+        deck_size=args.deck_size,
+        n_players=args.n_players,
+        max_cards=args.max_cards,
+        jokers=args.jokers,
+        blanks=args.blanks,
+        common_cards=args.common_cards,
+        seed=args.seed,
+    )
+    if args.output:
+        write_results_csv(args.output, results)
+        print(f"Wrote {len(results)} rows to {args.output}")
+    else:
+        w = csv.DictWriter(
+            sys.stdout,
+            fieldnames=[
+                "opponent", "config", "n_games", "wins", "losses", "draws",
+                "winrate", "winrate_ci_95", "mean_reward",
+                "mean_game_length_actions", "elapsed_seconds",
+            ],
+        )
+        w.writeheader()
+        for r in results:
+            w.writerow({k: getattr(r, k) for k in w.fieldnames})
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,5 @@
+# Optional tooling dependencies. Install only if you want to use
+# `tools/run_dashboard.py`. The eval ladder and backfill scripts use only
+# stdlib + project deps and don't require these.
+streamlit>=1.30
+pandas>=2.0

--- a/tools/run_dashboard.py
+++ b/tools/run_dashboard.py
@@ -1,0 +1,215 @@
+"""
+Streamlit dashboard for browsing per-run training metrics and ladder results.
+
+Layout:
+  - Sidebar lists timestamped run directories under `runs/` and ladder
+    backfills under `eval_results/`. Multi-select to overlay.
+  - Main panel: line charts (one per metric) with per-series toggles and
+    auto-refresh.
+
+Conventions this dashboard expects:
+  - Runs:        runs/<YYYYMMDD-HHMMSS>__<experiment-name>/metrics.csv
+  - Backfills:   eval_results/<checkpoint-name>/ladder.csv
+  - All CSVs are append-only line writes (atomic), so live runs update
+    incrementally as the trainer flushes.
+
+Launch from the repository root:
+
+  streamlit run tools/run_dashboard.py
+
+The browser tab stays open; new runs appear automatically as their dirs
+materialize.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from typing import Dict, List, Optional
+
+import pandas as pd
+import streamlit as st
+
+
+RUNS_DIR = os.environ.get("BLEF_RUNS_DIR", "runs")
+EVAL_DIR = os.environ.get("BLEF_EVAL_DIR", "eval_results")
+RUN_DIRNAME_RE = re.compile(r"^(?P<ts>\d{8}-\d{6})__(?P<name>.+)$")
+
+
+# --------------------------------------------------------------------------
+# Run discovery
+# --------------------------------------------------------------------------
+
+def _list_runs(root: str) -> List[Dict]:
+    """Return list of {dir, timestamp, name, csv_path} sorted newest-first."""
+    if not os.path.isdir(root):
+        return []
+    out = []
+    for entry in os.listdir(root):
+        full = os.path.join(root, entry)
+        if not os.path.isdir(full):
+            continue
+        m = RUN_DIRNAME_RE.match(entry)
+        if not m:
+            # Tolerate non-conforming dirs as "no timestamp" entries.
+            csv_path = os.path.join(full, "metrics.csv")
+            if os.path.exists(csv_path):
+                out.append({
+                    "dir": full,
+                    "timestamp": "",
+                    "name": entry,
+                    "csv_path": csv_path,
+                })
+            continue
+        csv_path = os.path.join(full, "metrics.csv")
+        if not os.path.exists(csv_path):
+            # Run dir created but no metrics yet; show it anyway.
+            csv_path = ""
+        out.append({
+            "dir": full,
+            "timestamp": m.group("ts"),
+            "name": m.group("name"),
+            "csv_path": csv_path,
+        })
+    out.sort(key=lambda r: r["timestamp"], reverse=True)
+    return out
+
+
+def _list_eval_backfills(root: str) -> List[Dict]:
+    if not os.path.isdir(root):
+        return []
+    out = []
+    for entry in sorted(os.listdir(root), reverse=True):
+        full = os.path.join(root, entry)
+        ladder = os.path.join(full, "ladder.csv")
+        if os.path.isdir(full) and os.path.exists(ladder):
+            out.append({"name": entry, "csv_path": ladder, "dir": full})
+    return out
+
+
+@st.cache_data(ttl=5)
+def _read_csv_safe(path: str) -> Optional[pd.DataFrame]:
+    if not path or not os.path.exists(path):
+        return None
+    try:
+        # Tolerate concurrent appends: read what's there.
+        return pd.read_csv(path)
+    except (pd.errors.EmptyDataError, pd.errors.ParserError):
+        return None
+
+
+# --------------------------------------------------------------------------
+# UI
+# --------------------------------------------------------------------------
+
+def main() -> None:
+    st.set_page_config(page_title="Blef NFSP Dashboard", layout="wide")
+    st.title("Blef NFSP — runs & eval ladder")
+
+    # Auto-refresh button. Streamlit reruns on widget interaction; this lets
+    # the user pull fresh CSVs without refreshing the whole page.
+    refresh_secs = st.sidebar.slider("Auto-refresh (seconds)", 0, 60, 10)
+    if refresh_secs > 0:
+        st.sidebar.markdown(
+            f"<small>Auto-refreshing every {refresh_secs}s. Disable: drag to 0.</small>",
+            unsafe_allow_html=True,
+        )
+
+    runs = _list_runs(RUNS_DIR)
+    backfills = _list_eval_backfills(EVAL_DIR)
+
+    st.sidebar.header("Runs")
+    if not runs:
+        st.sidebar.write(f"No runs found under `{RUNS_DIR}/`.")
+    selected_run_names = st.sidebar.multiselect(
+        "Overlay runs",
+        options=[r["name"] + (f" ({r['timestamp']})" if r["timestamp"] else "") for r in runs],
+        default=[],
+    )
+    selected_runs = [
+        r for r, label in zip(runs, [r["name"] + (f" ({r['timestamp']})" if r["timestamp"] else "") for r in runs])
+        if label in selected_run_names
+    ]
+
+    st.sidebar.header("Eval backfills")
+    selected_backfills = st.sidebar.multiselect(
+        "Compare ladder backfills",
+        options=[b["name"] for b in backfills],
+        default=[],
+    )
+
+    # ----- Run metrics -----
+    if selected_runs:
+        st.subheader("Training metrics")
+        frames = []
+        for r in selected_runs:
+            df = _read_csv_safe(r["csv_path"])
+            if df is None or df.empty:
+                continue
+            df = df.copy()
+            df["__run"] = r["name"]
+            frames.append(df)
+        if not frames:
+            st.info("Selected runs have no metrics CSV yet (or the file is empty).")
+        else:
+            all_df = pd.concat(frames, ignore_index=True)
+            x_col = "step" if "step" in all_df.columns else None
+            metric_cols = [
+                c for c in all_df.columns
+                if c not in {"__run", "step"}
+                and pd.api.types.is_numeric_dtype(all_df[c])
+            ]
+            picked = st.multiselect(
+                "Metrics to chart",
+                options=metric_cols,
+                default=[c for c in ("avg_reward", "win_rate", "q_loss", "sl_loss", "policy_entropy") if c in metric_cols][:5],
+            )
+            for col in picked:
+                if x_col:
+                    chart = (
+                        all_df.pivot_table(index=x_col, columns="__run", values=col, aggfunc="last")
+                              .sort_index()
+                    )
+                else:
+                    chart = all_df[[col, "__run"]].pivot_table(columns="__run", values=col, aggfunc="last")
+                st.markdown(f"**{col}**")
+                st.line_chart(chart, use_container_width=True)
+
+    # ----- Backfilled ladder -----
+    if selected_backfills:
+        st.subheader("Eval ladder (head-to-head winrate vs opponent)")
+        frames = []
+        chosen = [b for b in backfills if b["name"] in selected_backfills]
+        for b in chosen:
+            df = _read_csv_safe(b["csv_path"])
+            if df is None or df.empty:
+                continue
+            df = df.copy()
+            df["__checkpoint"] = b["name"]
+            frames.append(df)
+        if frames:
+            ladder = pd.concat(frames, ignore_index=True)
+            st.dataframe(ladder, use_container_width=True)
+            if {"opponent", "winrate", "__checkpoint"}.issubset(ladder.columns):
+                pivot = ladder.pivot_table(
+                    index="__checkpoint",
+                    columns="opponent",
+                    values="winrate",
+                    aggfunc="mean",
+                ).sort_index()
+                st.bar_chart(pivot)
+        else:
+            st.info("Selected backfills have no ladder.csv yet.")
+
+    # Footer
+    st.sidebar.markdown("---")
+    st.sidebar.markdown(f"<small>Runs dir: `{RUNS_DIR}` · Eval dir: `{EVAL_DIR}`</small>", unsafe_allow_html=True)
+
+    if refresh_secs > 0:
+        time.sleep(refresh_secs)
+        st.rerun()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

First PR of the NFSP audit roadmap. Stands up the **measurement** layer before any algorithmic change.

- Replaces the single ConservativeAgent winrate signal with a four-opponent **metric ladder**: \`random\` (floor) / \`conservative\` (current baseline) / \`cfr\` (near-Nash at low cardinality) / \`snapshot\` (self-improvement signal).
- Adds a **backfill script** that runs the ladder over historical \`.pt\` checkpoints — resumable, one \`eval_results/<ckpt>/ladder.csv\` per checkpoint.
- Adds a **Streamlit dashboard** that auto-discovers \`runs/<YYYYMMDD-HHMMSS>__<name>/\` and \`eval_results/\`, with multi-select overlay and per-series toggle.

No changes to the training loop, the algorithm, or any saved data. Eval is purely additive.

## Files

- \`tools/eval_ladder.py\` — head-to-head harness + CLI
- \`tools/backfill_eval.py\` — backfill CLI over a checkpoint glob
- \`tools/run_dashboard.py\` — Streamlit dashboard
- \`tools/requirements.txt\` — optional \`streamlit\` + \`pandas\` (dashboard only)
- \`tools/README.md\` — usage
- \`tests/test_eval_ladder.py\` — smoke tests (4/4 passing locally)

## Caveats / known gaps (intentional, addressed in later PRs)

- **CFR opponent auto-skips** when \`cfr_ai/outputs/\` is missing. The strategy CSVs live in production AWS, not in the repo. Pull them via the CLI before relying on the CFR rung.
- **Env config (deck_size / jokers / blanks / common_cards) must match the checkpoint's training config**, since checkpoints don't record their env config. A mismatch raises a clear \`ValueError\` rather than producing nonsense.
- **Live runs aren't yet rewired into \`runs/<ts>__<name>/\`** — that's a follow-up PR. The dashboard reads backfills today; live runs once \`nfsp_run_local.py\` is updated.
- **Run-management CLI (\`tools/run_manager.py\`)** for start/status/override/stop is intentionally deferred to its own focused PR.

## Test plan

- [x] \`python -m unittest tests.test_eval_ladder\` (4/4 passing)
- [x] \`python -m unittest tests.test_dynamic_probabilities tests.test_nfsp_run_local\` (regression)
- [ ] Manual: run \`python -m tools.eval_ladder --checkpoint <known-good-ckpt> --opponents random,conservative --n-games 200\` against a checkpoint trained with default env config (24-card, no jokers/blanks/common). Expect a finite winrate ±CI.
- [ ] Manual: run \`python -m tools.backfill_eval --pattern 'nfsp_blef_*_*M.pt' --opponents random,conservative --n-games 100\` and verify \`eval_results/<stem>/ladder.csv\` produced for each compatible checkpoint, with clear errors for mismatched configs.
- [ ] Manual: \`pip install -r tools/requirements.txt && streamlit run tools/run_dashboard.py\`, confirm runs and backfills appear in the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)