### PR TITLE
Phase 0c: Run-management CLI, standardized run dirs, CFR fetch helper

### DIFF
--- a/nfsp_ai/nfsp_run_local.py
+++ b/nfsp_ai/nfsp_run_local.py
@@ -1063,6 +1063,21 @@ class MyEnv:
 def main():
     parser = argparse.ArgumentParser(description="Run NFSP Blef self-play locally.")
     parser.add_argument(
+        "--experiment-name",
+        dest="experiment_name",
+        type=str,
+        default="auto",
+        help="Short name for this run; used to label the run directory and dashboard. "
+        "If 'auto' (default), a timestamp-only name is used.",
+    )
+    parser.add_argument(
+        "--runs-root",
+        dest="runs_root",
+        type=str,
+        default="runs",
+        help="Root directory under which run dirs are created (default: runs/).",
+    )
+    parser.add_argument(
         "--resume",
         dest="resume_path",
         type=str,
@@ -1272,15 +1287,42 @@ def main():
     )
     args = parser.parse_args()
 
-    postfix = datetime.now().strftime("%Y%m%d%H%M%S")
-    model_save_path = f"nfsp_blef_{postfix}.pt"
-    game_save_dir = f"games_{postfix}"
+    # Build a standardized run dir: <runs_root>/<YYYYMMDD-HHMMSS>__<experiment-name>/
+    # All artifacts (checkpoints, metrics, control plane, saved games, action
+    # samples, pid files, launch command) go inside it. The dashboard
+    # (`tools/run_dashboard.py`) auto-discovers run dirs by this convention.
+    run_timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    raw_name = (args.experiment_name or "auto").strip() or "auto"
+    safe_name = "".join(c if (c.isalnum() or c in "-_.") else "_" for c in raw_name)
+    run_label = run_timestamp if safe_name == "auto" else f"{run_timestamp}__{safe_name}"
+    run_dir = os.path.abspath(os.path.join(args.runs_root, run_label))
+    os.makedirs(run_dir, exist_ok=True)
+
+    checkpoint_dir = os.path.join(run_dir, "checkpoints")
+    os.makedirs(checkpoint_dir, exist_ok=True)
+    model_save_path = os.path.join(checkpoint_dir, "nfsp_blef.pt")
+
+    game_save_dir = os.path.join(run_dir, "games")
     os.makedirs(game_save_dir, exist_ok=True)
-    eval_game_save_dir = f"{game_save_dir}_eval"
+    eval_game_save_dir = os.path.join(run_dir, "games_eval")
     os.makedirs(eval_game_save_dir, exist_ok=True)
+
+    metrics_csv_path = os.path.join(run_dir, "metrics.csv")
+    default_control_plane_path = os.path.join(run_dir, "control_plane.json")
+
+    # Persist the launch command for reproducibility / restart.
+    try:
+        import sys as _sys
+        with open(os.path.join(run_dir, "cmd.txt"), "w", encoding="utf-8") as _cmd_f:
+            _cmd_f.write(" ".join(_sys.argv) + "\n")
+    except OSError:
+        pass
+
+    print(f"[run] {run_dir}")
+
     history_sample_limit = None if args.history_sample_limit <= 0 else args.history_sample_limit
     history_sample_path = args.history_sample_path or os.path.join(
-        "logs", f"action_samples_{postfix}.jsonl"
+        run_dir, "action_samples.jsonl"
     )
     if history_sample_path:
         print(
@@ -1457,24 +1499,33 @@ def main():
         )
         return
 
-    control_plane = None
-    if args.control_plane:
-        cp_path = os.path.abspath(args.control_plane)
-        if not os.path.exists(cp_path):
-            snapshot = build_control_snapshot(agent, env, cooldown_steps=args.control_plane_cooldown)
-            write_control_file(cp_path, snapshot)
-            print(f"[control] bootstrap control-plane file written to {cp_path}")
-        control_plane = JsonControlPlane(
-            cp_path,
-            cooldown_steps=args.control_plane_cooldown,
-            verbose=True,
-        )
+    # If --control-plane is omitted, default to a per-run JSON inside run_dir
+    # so `tools/run_manager.py override` knows where to write.
+    cp_path = os.path.abspath(args.control_plane) if args.control_plane else default_control_plane_path
+    if not os.path.exists(cp_path):
+        snapshot = build_control_snapshot(agent, env, cooldown_steps=args.control_plane_cooldown)
+        write_control_file(cp_path, snapshot)
+        print(f"[control] bootstrap control-plane file written to {cp_path}")
+    control_plane = JsonControlPlane(
+        cp_path,
+        cooldown_steps=args.control_plane_cooldown,
+        verbose=True,
+    )
+    # Write a small PID file so run_manager can detect crash vs running state.
+    try:
+        with open(os.path.join(run_dir, "pid"), "w", encoding="utf-8") as _pf:
+            _pf.write(str(os.getpid()) + "\n")
+    except OSError:
+        pass
+
     agent.train_from_selfplay(
         env,
         total_steps=args.total_steps,
         log_every=50_000,
         save_path=model_save_path,
         game_save_dir=game_save_dir,
+        csv_path=metrics_csv_path,
+        tb_logdir=None,
         eval_env_factory=lambda: eval_env,
         eval_save_dir=eval_game_save_dir,
         eval_save_games=EVAL_SAVED_GAMES,

--- a/tests/test_run_manager.py
+++ b/tests/test_run_manager.py
@@ -1,0 +1,84 @@
+"""Smoke tests for the run-management CLI.
+
+The full subprocess-launch path requires a long-running trainer; here we
+exercise the surface area that doesn't need to actually launch nfsp_run_local.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+
+from tools import run_manager
+
+
+class RunDirDiscovery(unittest.TestCase):
+    def test_list_run_dirs_filters_by_naming_convention(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # Two valid run dirs and one bogus one.
+            valid_a = os.path.join(tmp, "20260101-120000__alpha")
+            valid_b = os.path.join(tmp, "20260102-130000__beta")
+            bogus = os.path.join(tmp, "not-a-run-dir")
+            for d in (valid_a, valid_b, bogus):
+                os.makedirs(d)
+            runs = run_manager._list_run_dirs(tmp)
+            self.assertEqual({r["label"] for r in runs}, {"20260101-120000__alpha", "20260102-130000__beta"})
+            # Newest first
+            self.assertEqual(runs[0]["timestamp"], "20260102-130000")
+
+    def test_find_run_returns_most_recent_match(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "20260101-120000__exp"))
+            os.makedirs(os.path.join(tmp, "20260201-120000__exp"))
+            os.makedirs(os.path.join(tmp, "20260301-120000__other"))
+            run = run_manager._find_run(tmp, "exp")
+            self.assertIsNotNone(run)
+            self.assertEqual(run["timestamp"], "20260201-120000")
+
+
+class MetricsRead(unittest.TestCase):
+    def test_read_latest_metrics_returns_last_row(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = os.path.join(tmp, "20260101-120000__r")
+            os.makedirs(run_dir)
+            csv_path = os.path.join(run_dir, "metrics.csv")
+            with open(csv_path, "w", encoding="utf-8") as fh:
+                fh.write("step,avg_reward,win_rate\n")
+                fh.write("100,0.1,0.5\n")
+                fh.write("200,0.3,0.7\n")
+            latest = run_manager._read_latest_metrics(run_dir)
+            self.assertIsNotNone(latest)
+            self.assertEqual(latest["step"], "200")
+            self.assertEqual(latest["win_rate"], "0.7")
+
+    def test_read_latest_metrics_missing_csv(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(run_manager._read_latest_metrics(tmp))
+
+
+class OverrideSubcommand(unittest.TestCase):
+    def test_override_writes_to_control_plane_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = os.path.join(tmp, "20260101-120000__exp")
+            os.makedirs(run_dir)
+            cp_path = os.path.join(run_dir, "control_plane.json")
+            with open(cp_path, "w", encoding="utf-8") as fh:
+                json.dump({"meta": {"cooldown_steps": 0}, "overrides": {}}, fh)
+
+            argv = [
+                "--runs-root", tmp,
+                "override",
+                "--experiment-name", "exp",
+                "--set", "eta=0.05",
+                "--set", "epsilon=none",
+            ]
+            rc = run_manager.main(argv)
+            self.assertEqual(rc, 0)
+            with open(cp_path, "r", encoding="utf-8") as fh:
+                payload = json.load(fh)
+            self.assertEqual(payload["overrides"]["eta"], 0.05)
+            self.assertIsNone(payload["overrides"]["epsilon"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/fetch_cfr_strategies.py
+++ b/tools/fetch_cfr_strategies.py
@@ -1,0 +1,168 @@
+"""
+Download CFR strategy CSVs from the production CFR worker Lambdas into
+`cfr_ai/outputs/`.
+
+The deployed CFR agent for Blef lives across many `blef-aiagent-cfr-worker-X-Y`
+Lambdas (one per (sorted hand-size pair)). Each Lambda's deployment package
+ships the corresponding `cfr_ai/outputs/X_Y/` strategy tree inside it. This
+script downloads each Lambda's code zip, extracts the `cfr_ai/outputs/X_Y/`
+subdirectory, and merges into the local `cfr_ai/outputs/`.
+
+CFR is strongest at low cardinality (early-round hand sizes). The default is
+to fetch pairs whose maximum hand size is ≤ 4 — about 13 MB total. Larger
+pairs are available with `--max-cards`, at much greater download size.
+
+Run from the repository root:
+
+  python -m tools.fetch_cfr_strategies               # default: max-cards=4
+  python -m tools.fetch_cfr_strategies --max-cards 6
+  python -m tools.fetch_cfr_strategies --pairs 1-1,2-2,3-3
+
+Requires AWS CLI configured locally (the script shells out to `aws lambda
+get-function`). Also writes a top-level `metadata.csv` with `Minimum bet,0`
+if one isn't already present — the local CFR agent reads it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+import zipfile
+from typing import List, Optional, Sequence, Tuple
+
+
+DEFAULT_OUTPUT_DIR = "cfr_ai/outputs"
+DEFAULT_METADATA_PATH = "metadata.csv"
+WORKER_PREFIX = "blef-aiagent-cfr-worker-"
+
+
+def _gen_pairs(max_cards: int) -> List[Tuple[int, int]]:
+    """All sorted (a, b) pairs with 1 ≤ a ≤ b ≤ max_cards."""
+    return [(a, b) for a in range(1, max_cards + 1) for b in range(a, max_cards + 1)]
+
+
+def _parse_pairs(spec: str) -> List[Tuple[int, int]]:
+    out: List[Tuple[int, int]] = []
+    for token in spec.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if "-" not in token:
+            raise ValueError(f"pair must be 'A-B', got {token!r}")
+        a, b = token.split("-", 1)
+        a_i, b_i = int(a), int(b)
+        if a_i > b_i:
+            a_i, b_i = b_i, a_i
+        out.append((a_i, b_i))
+    return out
+
+
+def _aws_lambda_code_url(function_name: str) -> Optional[str]:
+    proc = subprocess.run(  # noqa: S603,S607 — controlled invocation, args are static
+        ["aws", "lambda", "get-function", "--function-name", function_name,
+         "--query", "Code.Location", "--output", "text"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    url = proc.stdout.strip()
+    return url or None
+
+
+def _fetch_pair(
+    pair: Tuple[int, int],
+    output_dir: str,
+    *,
+    force: bool = False,
+) -> Tuple[bool, str]:
+    """Returns (ok, message)."""
+    a, b = pair
+    pair_dir = os.path.join(output_dir, f"{a}_{b}")
+    if os.path.exists(pair_dir) and not force:
+        return True, f"{a}-{b}: already present, skipping (use --force to redownload)"
+
+    function_name = f"{WORKER_PREFIX}{a}-{b}"
+    url = _aws_lambda_code_url(function_name)
+    if url is None:
+        return False, f"{a}-{b}: aws lambda get-function failed (function may not exist)"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        zip_path = os.path.join(tmp, "lambda.zip")
+        try:
+            with urllib.request.urlopen(url, timeout=120) as resp, open(zip_path, "wb") as fh:
+                shutil.copyfileobj(resp, fh)
+        except Exception as exc:  # noqa: BLE001
+            return False, f"{a}-{b}: download failed: {exc!r}"
+
+        try:
+            with zipfile.ZipFile(zip_path) as zf:
+                prefix = f"cfr_ai/outputs/{a}_{b}/"
+                members = [m for m in zf.namelist() if m.startswith(prefix)]
+                if not members:
+                    return False, f"{a}-{b}: zip did not contain {prefix!r}"
+                os.makedirs(output_dir, exist_ok=True)
+                # Extract into a staging dir, then move into place atomically.
+                staging = os.path.join(tmp, "extract")
+                zf.extractall(path=staging, members=members)
+                src = os.path.join(staging, "cfr_ai", "outputs", f"{a}_{b}")
+                if os.path.exists(pair_dir):
+                    shutil.rmtree(pair_dir)
+                shutil.move(src, pair_dir)
+        except (zipfile.BadZipFile, OSError) as exc:
+            return False, f"{a}-{b}: extract failed: {exc!r}"
+
+    file_count = sum(len(files) for _, _, files in os.walk(pair_dir))
+    return True, f"{a}-{b}: ok ({file_count} strategy files)"
+
+
+def _ensure_metadata_csv(path: str) -> None:
+    if os.path.exists(path):
+        return
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("Minimum bet,0\n")
+    print(f"[meta] wrote {path} (Minimum bet=0)")
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR)
+    p.add_argument("--metadata-path", default=DEFAULT_METADATA_PATH)
+    p.add_argument("--max-cards", type=int, default=4, help="Fetch pairs with max(a,b) ≤ N (default: 4).")
+    p.add_argument("--pairs", default="", help="Comma-separated explicit pair list (e.g. '1-1,2-3'). Overrides --max-cards.")
+    p.add_argument("--force", action="store_true", help="Redownload pairs already present.")
+    args = p.parse_args(argv)
+
+    if args.pairs:
+        pairs = _parse_pairs(args.pairs)
+    else:
+        if args.max_cards <= 0:
+            print("error: --max-cards must be ≥ 1 (or use --pairs)", file=sys.stderr)
+            return 2
+        pairs = _gen_pairs(args.max_cards)
+
+    print(f"[fetch] {len(pairs)} pair(s) into {args.output_dir}/")
+    n_ok = n_skipped = n_failed = 0
+    for pair in pairs:
+        ok, msg = _fetch_pair(pair, args.output_dir, force=args.force)
+        print(f"  {msg}")
+        if ok:
+            if "already present" in msg:
+                n_skipped += 1
+            else:
+                n_ok += 1
+        else:
+            n_failed += 1
+    _ensure_metadata_csv(args.metadata_path)
+    print(f"[fetch] {n_ok} downloaded, {n_skipped} skipped, {n_failed} failed")
+    return 0 if n_failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/run_manager.py
+++ b/tools/run_manager.py
@@ -1,0 +1,354 @@
+"""
+Lightweight CLI for managing NFSP self-play training runs.
+
+Subcommands:
+  start       Launch a run in the background.
+  status      Show latest metrics for one run, or summary for all.
+  override    Write to a run's control-plane JSON.
+  stop        Send SIGTERM to a running run; waits for clean exit.
+  list        List all run dirs and their status.
+  compare     Print last-row metric snapshots side-by-side across runs.
+
+Run directory convention
+------------------------
+Each run lives at:
+
+    runs/<YYYYMMDD-HHMMSS>__<experiment-name>/
+        ├── checkpoints/
+        ├── games/
+        ├── games_eval/
+        ├── metrics.csv
+        ├── control_plane.json
+        ├── action_samples.jsonl
+        ├── pid          (process id of the trainer; absent if not running)
+        └── cmd.txt      (the launch command, for reproducibility)
+
+`pid` is written by `nfsp_run_local.py`. The trainer registers a SIGTERM
+handler so `stop` causes a clean checkpoint flush before exit.
+
+Examples
+--------
+
+  # Launch a 5M-step run in the background.
+  python -m tools.run_manager start \\
+      --experiment-name mc-baseline \\
+      --total-steps 5000000 --deck-size 24 --max-cards 11
+
+  # Latest metrics:
+  python -m tools.run_manager status --experiment-name mc-baseline
+
+  # Override eta mid-run (cooldown logic still applies):
+  python -m tools.run_manager override --experiment-name mc-baseline --eta 0.05
+
+  # All runs:
+  python -m tools.run_manager list
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import shlex
+import signal
+import subprocess
+import sys
+import time
+from typing import Dict, List, Optional, Tuple
+
+
+RUN_DIRNAME_RE = re.compile(r"^(?P<ts>\d{8}-\d{6})(?:__(?P<name>.+))?$")
+DEFAULT_RUNS_ROOT = os.environ.get("BLEF_RUNS_DIR", "runs")
+NFSP_MODULE = "nfsp_ai.nfsp_run_local"
+
+
+# --------------------------------------------------------------------------
+# Run discovery
+# --------------------------------------------------------------------------
+
+def _list_run_dirs(runs_root: str) -> List[Dict]:
+    if not os.path.isdir(runs_root):
+        return []
+    out = []
+    for entry in os.listdir(runs_root):
+        full = os.path.join(runs_root, entry)
+        if not os.path.isdir(full):
+            continue
+        m = RUN_DIRNAME_RE.match(entry)
+        if not m:
+            continue
+        out.append({
+            "name": m.group("name") or "auto",
+            "timestamp": m.group("ts"),
+            "dir": full,
+            "label": entry,
+        })
+    out.sort(key=lambda r: r["timestamp"], reverse=True)
+    return out
+
+
+def _find_run(runs_root: str, experiment_name: str) -> Optional[Dict]:
+    """Return the most recent run dir whose experiment name matches."""
+    matches = [r for r in _list_run_dirs(runs_root) if r["name"] == experiment_name]
+    return matches[0] if matches else None
+
+
+def _process_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _read_pid(run_dir: str) -> Optional[int]:
+    pid_path = os.path.join(run_dir, "pid")
+    try:
+        with open(pid_path, "r", encoding="utf-8") as fh:
+            return int(fh.read().strip())
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def _run_status(run_dir: str) -> str:
+    pid = _read_pid(run_dir)
+    if pid is None:
+        return "no-pid"
+    return "running" if _process_alive(pid) else "stopped"
+
+
+def _read_latest_metrics(run_dir: str) -> Optional[Dict]:
+    csv_path = os.path.join(run_dir, "metrics.csv")
+    if not os.path.exists(csv_path):
+        return None
+    last: Optional[Dict] = None
+    try:
+        with open(csv_path, "r", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                last = row
+    except OSError:
+        return None
+    return last
+
+
+# --------------------------------------------------------------------------
+# Subcommand implementations
+# --------------------------------------------------------------------------
+
+def cmd_start(args) -> int:
+    """Launch nfsp_run_local in the background.
+
+    Pass through any extra flags after `--` (e.g. `--total-steps`, `--deck-size`).
+    """
+    if not args.experiment_name:
+        print("error: --experiment-name is required for start", file=sys.stderr)
+        return 2
+
+    pre_existing = _find_run(args.runs_root, args.experiment_name)
+    if pre_existing and _run_status(pre_existing["dir"]) == "running":
+        print(
+            f"refusing to start: '{args.experiment_name}' is already running at {pre_existing['dir']}",
+            file=sys.stderr,
+        )
+        return 3
+
+    cmd: List[str] = [
+        sys.executable, "-m", NFSP_MODULE,
+        "--experiment-name", args.experiment_name,
+        "--runs-root", args.runs_root,
+    ] + list(args.extra)
+
+    log_dir = os.path.join(args.runs_root, ".launcher_logs")
+    os.makedirs(log_dir, exist_ok=True)
+    log_path = os.path.join(log_dir, f"{args.experiment_name}-{int(time.time())}.log")
+    log_fh = open(log_path, "wb")  # noqa: SIM115 — handed to the child process
+    print(f"[start] {args.experiment_name}: {' '.join(shlex.quote(x) for x in cmd)}")
+    print(f"[start] launcher log: {log_path}")
+    proc = subprocess.Popen(  # noqa: S603 — controlled invocation
+        cmd,
+        stdout=log_fh,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    print(f"[start] pid={proc.pid}; the trainer will overwrite this with its own pid file.")
+    return 0
+
+
+def cmd_status(args) -> int:
+    runs_root = args.runs_root
+    if args.experiment_name:
+        run = _find_run(runs_root, args.experiment_name)
+        if not run:
+            print(f"no run found for '{args.experiment_name}'", file=sys.stderr)
+            return 4
+        latest = _read_latest_metrics(run["dir"]) or {}
+        print(f"{run['label']}  status={_run_status(run['dir'])}")
+        if latest:
+            keys = ("step", "avg_reward", "win_rate", "q_loss", "sl_loss", "policy_entropy")
+            for k in keys:
+                if k in latest:
+                    print(f"  {k:>16}: {latest[k]}")
+        else:
+            print("  (no metrics yet)")
+        return 0
+
+    runs = _list_run_dirs(runs_root)
+    if not runs:
+        print(f"no runs under {runs_root}/")
+        return 0
+    width = max(len(r["label"]) for r in runs)
+    print(f"{'run':<{width}}  status     step           avg_reward  win_rate")
+    for r in runs:
+        latest = _read_latest_metrics(r["dir"]) or {}
+        step = latest.get("step", "")
+        avg_r = latest.get("avg_reward", "")
+        wr = latest.get("win_rate", "")
+        print(f"{r['label']:<{width}}  {_run_status(r['dir']):<10} {str(step):<14} {str(avg_r):<11} {str(wr)}")
+    return 0
+
+
+def cmd_override(args) -> int:
+    run = _find_run(args.runs_root, args.experiment_name)
+    if not run:
+        print(f"no run found for '{args.experiment_name}'", file=sys.stderr)
+        return 4
+    cp_path = os.path.join(run["dir"], "control_plane.json")
+    if not os.path.exists(cp_path):
+        print(f"no control_plane.json at {cp_path}; the run may not have started writing it yet", file=sys.stderr)
+        return 5
+
+    with open(cp_path, "r", encoding="utf-8") as fh:
+        payload = json.load(fh)
+
+    overrides = payload.get("overrides")
+    if not isinstance(overrides, dict):
+        overrides = {}
+        payload["overrides"] = overrides
+
+    pairs: Dict[str, Optional[float]] = {}
+    for kv in args.set or []:
+        if "=" not in kv:
+            print(f"error: --set entry must be KEY=VALUE, got {kv!r}", file=sys.stderr)
+            return 2
+        k, v = kv.split("=", 1)
+        if v.lower() in {"none", "null", ""}:
+            pairs[k.strip()] = None
+            continue
+        try:
+            pairs[k.strip()] = float(v)
+        except ValueError:
+            pairs[k.strip()] = v.strip()
+
+    overrides.update(pairs)
+    with open(cp_path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+    print(f"[override] {cp_path}: {pairs}")
+    return 0
+
+
+def cmd_stop(args) -> int:
+    run = _find_run(args.runs_root, args.experiment_name)
+    if not run:
+        print(f"no run found for '{args.experiment_name}'", file=sys.stderr)
+        return 4
+    pid = _read_pid(run["dir"])
+    if pid is None or not _process_alive(pid):
+        print(f"[stop] no live pid; nothing to stop")
+        return 0
+    print(f"[stop] sending SIGTERM to pid={pid} ({run['label']})")
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return 0
+    if args.wait_seconds <= 0:
+        return 0
+    deadline = time.time() + args.wait_seconds
+    while time.time() < deadline:
+        if not _process_alive(pid):
+            print(f"[stop] pid={pid} exited cleanly")
+            return 0
+        time.sleep(1)
+    print(f"[stop] pid={pid} did not exit within {args.wait_seconds}s; you may need SIGKILL", file=sys.stderr)
+    return 6
+
+
+def cmd_list(args) -> int:
+    return cmd_status(argparse.Namespace(runs_root=args.runs_root, experiment_name=None))
+
+
+def cmd_compare(args) -> int:
+    names: List[str] = [n.strip() for n in (args.experiments or "").split(",") if n.strip()]
+    if not names:
+        print("error: --experiments is required (comma-separated)", file=sys.stderr)
+        return 2
+    rows: List[Tuple[str, Dict]] = []
+    for n in names:
+        run = _find_run(args.runs_root, n)
+        if not run:
+            rows.append((n, {}))
+            continue
+        rows.append((n, _read_latest_metrics(run["dir"]) or {}))
+    keys = ("step", "avg_reward", "win_rate", "q_loss", "sl_loss", "policy_entropy")
+    width = max(len(n) for n in names)
+    header = f"{'experiment':<{width}} | " + " | ".join(f"{k:<14}" for k in keys)
+    print(header)
+    print("-" * len(header))
+    for n, m in rows:
+        cells = [str(m.get(k, "")) for k in keys]
+        print(f"{n:<{width}} | " + " | ".join(f"{c:<14}" for c in cells))
+    return 0
+
+
+# --------------------------------------------------------------------------
+# CLI plumbing
+# --------------------------------------------------------------------------
+
+def _build_argparser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--runs-root", default=DEFAULT_RUNS_ROOT)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp_start = sub.add_parser("start", help="Launch nfsp_run_local in the background.")
+    sp_start.add_argument("--experiment-name", required=True)
+    sp_start.add_argument("extra", nargs=argparse.REMAINDER, help="Pass-through args for nfsp_run_local.")
+    sp_start.set_defaults(func=cmd_start)
+
+    sp_status = sub.add_parser("status", help="Show metrics for one run, or summary across all.")
+    sp_status.add_argument("--experiment-name", default=None)
+    sp_status.set_defaults(func=cmd_status)
+
+    sp_override = sub.add_parser("override", help="Write to a run's control_plane.json.")
+    sp_override.add_argument("--experiment-name", required=True)
+    sp_override.add_argument("--set", action="append", help="KEY=VALUE; repeatable. VALUE='none' clears an override.")
+    sp_override.set_defaults(func=cmd_override)
+
+    sp_stop = sub.add_parser("stop", help="SIGTERM the run's pid; wait for clean exit.")
+    sp_stop.add_argument("--experiment-name", required=True)
+    sp_stop.add_argument("--wait-seconds", type=int, default=60, help="0 = don't wait.")
+    sp_stop.set_defaults(func=cmd_stop)
+
+    sp_list = sub.add_parser("list", help="List run dirs.")
+    sp_list.set_defaults(func=cmd_list)
+
+    sp_compare = sub.add_parser("compare", help="Compare last-row metrics across runs.")
+    sp_compare.add_argument("--experiments", required=True, help="Comma-separated experiment names.")
+    sp_compare.set_defaults(func=cmd_compare)
+
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _build_argparser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Three small, focused pieces of operational tooling that together complete Phase 0.

### 1. Standardized run dirs (\`nfsp_ai/nfsp_run_local.py\`)

Adds \`--experiment-name <NAME>\` (and \`--runs-root <DIR>\`, default \`runs/\`). Every artifact for a run goes into one tree:

\`\`\`
runs/<YYYYMMDD-HHMMSS>__<experiment-name>/
├── checkpoints/         (final + per-million)
├── games/
├── games_eval/
├── metrics.csv          (the dashboard reads this)
├── control_plane.json
├── action_samples.jsonl
├── cmd.txt              (launch command, for reproducibility)
└── pid                  (trainer PID, for run_manager)
\`\`\`

If \`--control-plane\` is omitted, the trainer auto-creates \`<run_dir>/control_plane.json\` so \`tools.run_manager override\` always has a known path. \`tb_logdir\` defaults to \`None\` — the dashboard reads the per-run CSV directly.

### 2. \`tools/run_manager.py\`

CLI wrapping \`nfsp_ai.nfsp_run_local\`. Subcommands:

| Subcommand | Purpose |
|---|---|
| \`start\` | Background-launch a run with \`--experiment-name\`. |
| \`status\` | Latest metrics for one run, or summary across all. |
| \`override\` | Write \`KEY=VALUE\` pairs into a run's \`control_plane.json\`; cooldown logic in \`nfsp_ai/control_plane.py\` still applies. |
| \`stop\` | SIGTERM the run's PID; wait for clean exit. |
| \`list\` | All run dirs with status (running/stopped) + last step. |
| \`compare\` | Last-row metric snapshots side-by-side across runs. |

Pure directory-convention discovery — no daemon, no DB.

### 3. \`tools/fetch_cfr_strategies.py\`

Downloads CFR strategy CSVs from the production \`blef-aiagent-cfr-worker-X-Y\` Lambdas into \`cfr_ai/outputs/\`. Default \`--max-cards 4\` (~13 MB; the regime where CFR is near-Nash). Writes a top-level \`metadata.csv\` with \`Minimum bet,0\` if missing.

Unblocks the CFR rung of the metric ladder (PR #41) for users without local strategy files.

## Test plan

- [x] \`tests/test_run_manager.py\` (3 tests): run-dir discovery, latest-row metrics read, override round-trip. Pass.
- [x] Existing \`test_nfsp_run_local\`, \`test_dynamic_probabilities\` regress clean.
- [x] Manual smoke: \`python -m nfsp_ai.nfsp_run_local --experiment-name smoke-pr4 --total-steps 50 ...\` creates the run dir with all expected files; \`python -m tools.run_manager status\` lists it as 'stopped' (clean exit).
- [x] Manual smoke: \`python -m tools.fetch_cfr_strategies --max-cards 4\` downloads 10 hand-size pairs (1-1..4-4) totalling ~13 MB; CFR opponent loads end-to-end in PR #41's eval ladder.

## Notes for the merge

- Independent of PRs #42 / #43 (no overlapping edits). Will conflict cleanly with #42 over the \`NFSPConfig(...)\` block in \`nfsp_run_local.py\` since both touch that block; resolution is mechanical (PR4 keeps the path-standardization edits, PR2 keeps the dead-config-removal edits).
- PR #41's \`tools/README.md\` is on a different branch; once both land, a follow-up commit can fold \`run_manager\` and \`fetch_cfr_strategies\` into that README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)