### PR TITLE
run_manager: handle '--' passthrough; merge same-step CSV rows in status

### DIFF
--- a/tests/test_run_manager.py
+++ b/tests/test_run_manager.py
@@ -55,6 +55,26 @@ class MetricsRead(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             self.assertIsNone(run_manager._read_latest_metrics(tmp))
 
+    def test_read_latest_metrics_merges_same_step_rows(self):
+        # The trainer writes two rows per step: a training row with q_loss/sl_loss
+        # populated and an eval row with avg_reward/win_rate populated but losses
+        # 'nan'. Status should merge them so the user sees one combined snapshot.
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = os.path.join(tmp, "20260101-120000__r")
+            os.makedirs(run_dir)
+            csv_path = os.path.join(run_dir, "metrics.csv")
+            with open(csv_path, "w", encoding="utf-8") as fh:
+                fh.write("step,avg_reward,win_rate,q_loss,sl_loss\n")
+                fh.write("100,0.5,0.6,0.20,1.8\n")
+                fh.write("100,0.3,0.55,nan,nan\n")
+            latest = run_manager._read_latest_metrics(run_dir)
+            self.assertIsNotNone(latest)
+            self.assertEqual(latest["step"], "100")
+            self.assertEqual(latest["q_loss"], "0.20")
+            self.assertEqual(latest["sl_loss"], "1.8")
+            self.assertEqual(latest["avg_reward"], "0.3")
+            self.assertEqual(latest["win_rate"], "0.55")
+
 
 class OverrideSubcommand(unittest.TestCase):
     def test_override_writes_to_control_plane_json(self):

--- a/tools/run_manager.py
+++ b/tools/run_manager.py
@@ -124,18 +124,33 @@ def _run_status(run_dir: str) -> str:
 
 
 def _read_latest_metrics(run_dir: str) -> Optional[Dict]:
+    """Return the latest metrics row, merging training + eval rows that share
+    the same `step` value (the trainer writes one of each per log cycle, with
+    different fields populated).
+    """
     csv_path = os.path.join(run_dir, "metrics.csv")
     if not os.path.exists(csv_path):
         return None
-    last: Optional[Dict] = None
+    rows: List[Dict] = []
     try:
         with open(csv_path, "r", encoding="utf-8") as fh:
             reader = csv.DictReader(fh)
             for row in reader:
-                last = row
+                rows.append(row)
     except OSError:
         return None
-    return last
+    if not rows:
+        return None
+    last_step = rows[-1].get("step")
+    same_step = [r for r in rows if r.get("step") == last_step]
+    if not same_step:
+        return rows[-1]
+    merged: Dict[str, str] = dict(same_step[0])
+    for r in same_step[1:]:
+        for k, v in r.items():
+            if v not in (None, "", "nan"):
+                merged[k] = v
+    return merged
 
 
 # --------------------------------------------------------------------------
@@ -159,11 +174,16 @@ def cmd_start(args) -> int:
         )
         return 3
 
+    # Strip leading '--' separator if caller used `start --experiment-name X -- ...`
+    extras = list(args.extra)
+    while extras and extras[0] == "--":
+        extras.pop(0)
+
     cmd: List[str] = [
         sys.executable, "-m", NFSP_MODULE,
         "--experiment-name", args.experiment_name,
         "--runs-root", args.runs_root,
-    ] + list(args.extra)
+    ] + extras
 
     log_dir = os.path.join(args.runs_root, ".launcher_logs")
     os.makedirs(log_dir, exist_ok=True)


### PR DESCRIPTION
Two small fixes uncovered while babysitting the first post-merge calibration run.

1. `start --experiment-name X -- --total-steps 1000000 ...` now works. The literal `--` separator was being forwarded to `nfsp_run_local` and crashed it.

2. `status` merges training+eval CSV rows at the same step. The trainer writes two rows per log cycle (training row populates losses; eval row populates win-rate, with losses as 'nan'). Status used to return only the last row → NaN losses despite healthy training.

Verified live against the in-flight calibration run: status now shows q_loss=0.15, sl_loss=1.76, avg_reward=0.17, win_rate=0.585 at step 400k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
