### PR TITLE
Add random-initial-cards (RIC) scenario sampling for buffer diversity

### DIFF
--- a/nfsp_ai/nfsp_run_local.py
+++ b/nfsp_ai/nfsp_run_local.py
@@ -773,6 +773,7 @@ class MyEnv:
         pick_jokers_in_range: bool = False,
         pick_blanks_in_range: bool = False,
         pick_common_cards_in_range: bool = False,
+        scenario_init_max_cards: int = 0,
     ):
         if n_agents < 2 or n_agents > 8:
             raise ValueError("n_agents must be in [2, 8]")
@@ -809,6 +810,7 @@ class MyEnv:
         self.pick_jokers_in_range = pick_jokers_in_range
         self.pick_blanks_in_range = pick_blanks_in_range
         self.pick_common_cards_in_range = pick_common_cards_in_range
+        self.scenario_init_max_cards = max(0, int(scenario_init_max_cards))
 
         self.game: Dict = {}
         self._last_obs = None
@@ -869,6 +871,16 @@ class MyEnv:
         common_cards = self.common_card_cap
         if self.pick_common_cards_in_range:
             common_cards = random.randint(0, self.common_card_cap)
+        # Random-initial-cards (RIC) scenario sampling: when set, each player's
+        # opening hand size is sampled uniformly from [1, scenario_init_max_cards],
+        # exposing the network to high-cardinality states from step 0 instead of
+        # waiting for them to arise organically (which they rarely do — see
+        # buffer-distribution diagnostic in tools/diagnose_buffer.py and plan
+        # docs/phase_plan.md §111).
+        init_card_dist = None
+        cap = getattr(self, "scenario_init_max_cards", 0) or 0
+        if cap >= 2:
+            init_card_dist = [random.randint(1, cap) for _ in range(n_agents)]
         # Normal path: start a completely new game (either there was no pending round boundary or the game finished)
         self.game = gm.create_game(
             n_agents,
@@ -878,6 +890,7 @@ class MyEnv:
             blanks=blanks,
             common_cards=common_cards,
             verbose=self.verbose,
+            init_card_dist=init_card_dist,
         )
         # Sync rules from the created game (single assignment; remove duplicate)
         self.rules = dict(self.game.get("rules", self.rules))
@@ -1170,6 +1183,19 @@ def main():
         help="Sample the number of community cards uniformly from [0, --common-cards] for each new game.",
     )
     parser.add_argument(
+        "--scenario-init-max-cards",
+        dest="scenario_init_max_cards",
+        type=int,
+        default=0,
+        help=(
+            "Random-initial-cards (RIC) scenario sampling: when N>=2, every new "
+            "game starts with each player's hand size sampled uniformly from "
+            "[1, N]. Forces the replay buffer to populate diverse card counts "
+            "from step 0, addressing buffer-distribution starvation (see "
+            "docs/phase_plan.md §111 and tools/diagnose_buffer.py)."
+        ),
+    )
+    parser.add_argument(
         "--eval-only",
         dest="eval_only",
         action="store_true",
@@ -1412,6 +1438,7 @@ def main():
         pick_jokers_in_range=args.pick_jokers_in_range,
         pick_blanks_in_range=args.pick_blanks_in_range,
         pick_common_cards_in_range=args.pick_common_cards_in_range,
+        scenario_init_max_cards=args.scenario_init_max_cards,
     )
     obs0, mask0, _ = env.reset()
 
@@ -1465,6 +1492,9 @@ def main():
         pick_jokers_in_range=args.pick_jokers_in_range,
         pick_blanks_in_range=args.pick_blanks_in_range,
         pick_common_cards_in_range=args.pick_common_cards_in_range,
+        # Eval env intentionally does NOT use scenario_init_max_cards: the RIC
+        # curriculum is a training-time intervention; eval scores the agent on
+        # natural-distribution starts (all players begin with 1 card).
     )
 
     if args.export_inference:

--- a/shared/api/simpleschema_local_manager.py
+++ b/shared/api/simpleschema_local_manager.py
@@ -240,13 +240,24 @@ def create_game(
     blanks=0,
     common_cards=0,
     verbose=False,
+    init_card_dist=None,
 ):
     if n_agents < 2:
         raise ValueError("n_agents < 2")
     if n_agents > 8:
         raise ValueError("n_agents > 8")
     game_uuid = str(uuid.uuid4())
-    players = [{"nickname": str(i), "n_cards": 1} for i in range(n_agents)]
+    if init_card_dist is None:
+        players = [{"nickname": str(i), "n_cards": 1} for i in range(n_agents)]
+    else:
+        if len(init_card_dist) != n_agents:
+            raise ValueError(
+                f"init_card_dist length {len(init_card_dist)} must equal n_agents {n_agents}"
+            )
+        players = [
+            {"nickname": str(i), "n_cards": int(max(1, init_card_dist[i]))}
+            for i in range(n_agents)
+        ]
     if len(players) > 2:
         default_max_cards = floor(deck_size / len(players))
     else:


### PR DESCRIPTION
## Empirical motivation

Buffer-distribution starvation hypothesis from \`docs/phase_plan.md\` §111 confirmed. Running \`tools/diagnose_buffer.py\` on 9M-step checkpoint of \`mc-baseline-10M\`:

\`\`\`
RL buffer (1M transitions sampled, all from max_cards=11 self-play):
  1 cards: 27.79%   2: 33.22%   3: 27.75%   4: 11.24%
  >4 cards:  0.00%   <-- network has NEVER seen late-game
\`\`\`

Every game starts at all-1-card; natural play rarely produces high-cardinality states. The agent therefore trains entirely on early-game.

## What

\`--scenario-init-max-cards N\` (default 0 = off). When N≥2, every new game starts with each player's hand size drawn uniformly from [1, N]. \`create_game()\` gains an \`init_card_dist\` parameter; \`MyEnv.reset()\` constructs that list when configured.

Eval env intentionally skips RIC — RIC is a training-time intervention; eval scores on natural-distribution starts.

## Backward compatibility

Flag default 0 → identical behavior to current code path.

## Verified

- \`create_game(2, ..., init_card_dist=[5, 2])\` → players have 5/2 cards, draws match
- 20k-step smoke run with \`--scenario-init-max-cards 6\` runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)