### PR TITLE
Add --hidden-width CLI flag for network capacity sweep

### DIFF
--- a/nfsp_ai/nfsp_run_local.py
+++ b/nfsp_ai/nfsp_run_local.py
@@ -1186,6 +1186,18 @@ def main():
         help="Sample the number of community cards uniformly from [0, --common-cards] for each new game.",
     )
     parser.add_argument(
+        "--hidden-width",
+        dest="hidden_width",
+        type=int,
+        default=128,
+        help=(
+            "Hidden layer width for both Q and policy networks (default: 128). "
+            "Larger values may extract more signal at the cost of more compute "
+            "and overfitting risk on starved data — only useful after the "
+            "buffer-distribution issue is fixed (see plan_v2 §6.2)."
+        ),
+    )
+    parser.add_argument(
         "--randomize-initial-hands",
         dest="randomize_initial_hands",
         action="store_true",
@@ -1465,7 +1477,7 @@ def main():
             n_step=6,
             burst_rl_updates_on_reward=4,
             burst_reward_threshold=0.5,
-            hidden=128
+            hidden=int(args.hidden_width),
         ),
     )
 


### PR DESCRIPTION
## Why

Plan_v2 §6.2 calls for a width sweep on top of pin+emb. Network width was hardcoded at 128 in \`NFSPConfig\`. This is one of the first questions to answer once the buffer-distribution issue is addressed.

## What

\`--hidden-width N\` (default 128). Wires through to \`NFSPConfig.hidden\`. Default behavior unchanged.

## Empirical motivation

Pin+emb (no RIH) plateaued at mean=0.62-0.64 vs Conservative across 5M+ training steps (5 cell-evals on the C-LONG trajectory). If the plateau is **capacity-bound**, a wider network breaks it; if it's **overfitting on starved data**, a narrower one helps. Plan §218 flagged both possibilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)