### PR TITLE
eval_ladder: fix --use-card/history-embeddings auto-resolution

### DIFF
--- a/tools/eval_ladder.py
+++ b/tools/eval_ladder.py
@@ -498,8 +498,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             _resolve_card_embedding_path,
             _load_card_embedding,
         )
-        flag_value = None if args.use_card_embeddings == "auto" else args.use_card_embeddings
-        path = _resolve_card_embedding_path(flag_value, args.deck_size)
+        path = _resolve_card_embedding_path(args.use_card_embeddings, args.deck_size)
         if path is None:
             print(f"warning: --use-card-embeddings {args.use_card_embeddings!r} did not resolve to a file", file=sys.stderr)
         else:
@@ -509,8 +508,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             _resolve_history_embedding_path,
             _load_history_embedding,
         )
-        flag_value = None if args.use_history_embeddings == "auto" else args.use_history_embeddings
-        path = _resolve_history_embedding_path(flag_value, args.deck_size)
+        path = _resolve_history_embedding_path(args.use_history_embeddings, args.deck_size)
         if path is None:
             print(f"warning: --use-history-embeddings {args.use_history_embeddings!r} did not resolve to a file", file=sys.stderr)
         else:


### PR DESCRIPTION
## Summary
- The \`auto\` sentinel for \`--use-card-embeddings\` / \`--use-history-embeddings\` was converted to \`None\` before being passed to the resolver, so \`_resolve_card_embedding_path("auto"|None, deck_size)\` short-circuited and never attempted the auto candidates.
- Result: evaluating embedding-trained checkpoints with bare \`--use-card-embeddings --use-history-embeddings\` (no explicit path) failed with \`Env obs_dim 326 does not match learner obs_dim 390\`.
- Fix: pass the flag value through unmodified — the resolver already handles \`"auto"\`.

## Test plan
- [x] \`python -m tools.eval_ladder --checkpoint <emb-ckpt> --use-card-embeddings --use-history-embeddings ...\` now resolves to \`artifacts/{card,history}_embedding_pretrain_24.pt\` and runs without obs_dim mismatch.
- [x] Verified end-to-end on Explore-3M and W256-3M overnight evaluation grids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)