### PR TITLE
eval_ladder: treat empty CSV file as new in write_results_csv

### DIFF
--- a/tools/eval_ladder.py
+++ b/tools/eval_ladder.py
@@ -432,11 +432,15 @@ def write_results_csv(path: str, results: List[MatchResult]) -> None:
         "winrate", "winrate_ci_95", "mean_reward",
         "mean_game_length_actions", "elapsed_seconds",
     ]
-    new_file = not os.path.exists(path)
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-    with open(path, "a" if not new_file else "w", newline="") as f:
+    # Treat a zero-byte file the same as a missing one. Tools like mktemp(1)
+    # create an empty placeholder; without this, the writer would open in
+    # append mode and skip the header, silently producing a header-less CSV
+    # whose first data row is then dropped by downstream `tail -n +2` filters.
+    has_existing_data = os.path.exists(path) and os.path.getsize(path) > 0
+    with open(path, "a" if has_existing_data else "w", newline="") as f:
         w = csv.DictWriter(f, fieldnames=fieldnames)
-        if new_file:
+        if not has_existing_data:
             w.writeheader()
         for r in results:
             row = {k: getattr(r, k) for k in fieldnames}


### PR DESCRIPTION
## Summary
- \`write_results_csv\` decided whether to write a CSV header based on \`os.path.exists(path)\`. When callers pre-create the path (e.g. via \`mktemp(1)\`, which leaves an empty placeholder) and pass it as \`--output\`, the writer opened in append mode and skipped the header.
- Downstream consumers using \`tail -n +2\` to skip the header then dropped the first **data** row instead — silently losing the \`random\` opponent from every \`eval_grid.sh\` cell.
- Fix: only treat the file as existing when \`os.path.getsize(path) > 0\`.

## Test plan
- [x] Re-ran \`eval_grid.sh\` on Explore-5M; \`random\` rows now present (winrate ≈ 1.0 vs random as expected).
- [x] No regression for callers that pre-existed with content (still appends without re-emitting the header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)