### PR TITLE
tools/exploitability.py + br-self opponent for NashConv

### DIFF
--- a/tools/eval_ladder.py
+++ b/tools/eval_ladder.py
@@ -154,6 +154,40 @@ class SnapshotOpponent(Opponent):
         return self.agent.select_action(obs, mask, use_average_policy=True, greedy=True)
 
 
+class BRSelfOpponent(Opponent):
+    """Best-response opponent using the *same* checkpoint's Q-net — i.e. the
+    learner's own Q. Used for exploitability estimation: if BR-vs-avg wins
+    significantly above 0.5, the avg policy is exploitable (sub-Nash).
+
+    NashConv lower bound = 2 * (BR_winrate - 0.5), reaching 0 at Nash.
+    """
+
+    def __init__(self, checkpoint_path: str, obs_dim: int, act_dim: int,
+                 device: Optional[torch.device] = None, label: Optional[str] = None):
+        self.checkpoint_path = checkpoint_path
+        self.name = label or "br-self"
+        self.device = device or torch.device("cpu")
+        # Detect hidden width to match the learner's architecture.
+        state = torch.load(checkpoint_path, map_location=self.device, weights_only=False)
+        try:
+            hidden = _detect_hidden_from_checkpoint(state)
+        except Exception:
+            hidden = 128
+        cfg = NFSPConfig(rl_capacity=1, sl_capacity=1, hidden=hidden)
+        # Sniff factorize_action_head from the saved cfg if present.
+        saved_cfg = state.get("cfg") or {}
+        cfg.factorize_action_head = bool(saved_cfg.get("factorize_action_head", False))
+        self.agent = NFSPAgent(obs_dim, act_dim, device=self.device, cfg=cfg)
+        if "q" in state:
+            self.agent.q.load_state_dict(state["q"])
+        if "pi" in state:
+            self.agent.pi.load_state_dict(state["pi"])
+
+    def act(self, game_state, obs, mask):
+        # Best-response: argmax over Q-values on legal actions.
+        return self.agent.select_action(obs, mask, use_average_policy=False, greedy=True)
+
+
 # --------------------------------------------------------------------------
 # Match runner
 # --------------------------------------------------------------------------
@@ -407,6 +441,7 @@ def build_opponents(
     obs_dim: int,
     act_dim: int,
     snapshot_paths: Optional[List[str]] = None,
+    self_checkpoint_path: Optional[str] = None,
 ) -> List[Opponent]:
     out: List[Opponent] = []
     for name in (spec.split(",") if spec else []):
@@ -416,6 +451,11 @@ def build_opponents(
         if name == "snapshot":
             for p in (snapshot_paths or []):
                 out.append(SnapshotOpponent(p, obs_dim, act_dim))
+            continue
+        if name == "br-self":
+            if self_checkpoint_path is None:
+                raise ValueError("br-self opponent requires --checkpoint to be provided")
+            out.append(BRSelfOpponent(self_checkpoint_path, obs_dim, act_dim))
             continue
         builder = OPPONENT_REGISTRY.get(name)
         if not builder:
@@ -522,7 +562,13 @@ def _build_argparser() -> argparse.ArgumentParser:
     p.add_argument(
         "--opponents",
         default="random,conservative",
-        help="Comma-separated subset of {random, conservative, cfr, snapshot}.",
+        help=(
+            "Comma-separated subset of "
+            "{random, conservative, cfr, snapshot, br-self}. "
+            "`br-self` uses the same checkpoint's Q-net as a best-response "
+            "opponent — winrate above 0.5 = avg policy is exploitable, "
+            "i.e. NashConv lower bound = 2*(BR-vs-avg-winrate - 0.5)."
+        ),
     )
     p.add_argument("--snapshot-paths", default="", help="Comma-separated checkpoint paths (used when opponents includes 'snapshot').")
     p.add_argument("--n-games", type=int, default=200)
@@ -584,7 +630,9 @@ def main(argv: Optional[List[str]] = None) -> int:
         else:
             history_embedding = _load_history_embedding(path, device="cpu")
 
-    opponents = build_opponents(args.opponents, learner.obs_dim, learner.act_dim, snapshot_paths=snap_paths)
+    opponents = build_opponents(args.opponents, learner.obs_dim, learner.act_dim,
+                                  snapshot_paths=snap_paths,
+                                  self_checkpoint_path=args.checkpoint)
     if not opponents:
         print("No opponents constructed — exiting.", file=sys.stderr)
         return 2

--- a/tools/exploitability.py
+++ b/tools/exploitability.py
@@ -1,0 +1,193 @@
+"""Exploitability metrics for an NFSP-trained checkpoint.
+
+Reports 4 complementary signals that all answer "how far is this policy
+from a Nash equilibrium":
+
+  1. BR-vs-avg winrate — opponent uses the same checkpoint's Q-net as a
+     best-response; learner uses its average policy. Winrate above 0.5
+     means the avg policy is exploitable. Formal: NashConv lower bound
+     = 2 * (BR-vs-avg winrate - 0.5).
+
+  2. Symmetric NashConv (sum of BRs) — for a symmetric 2-player zero-sum
+     game, NashConv = BR0_winrate + BR1_winrate - 1. Reaching 0 means
+     both seats' BRs cannot exploit the other's avg policy.
+
+  3. Per-round-state BR exploitability — same as (1) but binned by
+     (our_n_cards, opp_n_cards). Reveals whether exploitability is
+     uniform across game phases or concentrated in early/late game.
+
+  4. Vs frozen-self winrate — current avg policy vs a snapshot loaded
+     from a different checkpoint path. Sanity check for "is this
+     checkpoint better than the previous one I trained?". Skipped
+     unless --baseline-checkpoint is provided.
+
+Output: pretty-printed table on stdout + optional CSV.
+"""
+from __future__ import annotations
+import argparse
+import csv
+import os
+import sys
+from typing import Dict, Optional, Tuple
+
+# Add the work tree to path so `nfsp_ai`/`tools` imports resolve when
+# invoked from a different cwd.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+import torch  # noqa: E402
+
+from tools.eval_ladder import (  # noqa: E402
+    BRSelfOpponent,
+    SnapshotOpponent,
+    head_to_head,
+    load_learner,
+    write_per_bin_csv,
+)
+
+
+def _fmt(x: float) -> str:
+    return f"{x:.4f}" if isinstance(x, (int, float)) else str(x)
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--checkpoint", required=True, help="NFSP checkpoint to analyze.")
+    p.add_argument("--n-games", type=int, default=2000,
+                   help="Games per BR-vs-avg evaluation (default 2000).")
+    p.add_argument("--deck-size", type=int, default=24)
+    p.add_argument("--n-players", type=int, default=2,
+                   help="Only 2-player exploitability is interpretable as NashConv.")
+    p.add_argument("--max-cards", type=int, default=11)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--baseline-checkpoint", default="",
+                   help="Optional prior checkpoint to test 'is current better than previous'.")
+    p.add_argument("--use-card-embeddings", nargs="?", const="auto", default=None)
+    p.add_argument("--use-history-embeddings", nargs="?", const="auto", default=None)
+    p.add_argument("--bin-output", default="",
+                   help="If set, write per-(our, opp) cards exploitability CSV.")
+    p.add_argument("--csv-output", default="",
+                   help="Headline metrics CSV (one row per metric).")
+    args = p.parse_args(argv)
+
+    if args.n_players != 2:
+        print("warning: NashConv interpretation only valid for 2-player.", file=sys.stderr)
+
+    # Resolve embeddings (re-uses the same logic as eval_ladder).
+    card_embedding = None
+    history_embedding = None
+    if args.use_card_embeddings:
+        from nfsp_ai.nfsp_run_local import _resolve_card_embedding_path, _load_card_embedding
+        path = _resolve_card_embedding_path(args.use_card_embeddings, args.deck_size)
+        if path is not None:
+            card_embedding = _load_card_embedding(path, device="cpu")
+    if args.use_history_embeddings:
+        from nfsp_ai.nfsp_run_local import _resolve_history_embedding_path, _load_history_embedding
+        path = _resolve_history_embedding_path(args.use_history_embeddings, args.deck_size)
+        if path is not None:
+            history_embedding = _load_history_embedding(path, device="cpu")
+
+    learner = load_learner(args.checkpoint)
+    common_kwargs = dict(
+        n_games=args.n_games,
+        deck_size=args.deck_size,
+        n_players=args.n_players,
+        max_cards=args.max_cards,
+        seed=args.seed,
+        card_embedding=card_embedding,
+        history_embedding=history_embedding,
+        use_average_policy=True,
+        greedy_learner=True,
+    )
+
+    # Metric 1: BR-vs-avg (learner = avg policy, opponent = own Q best-response).
+    print("Running metric 1: BR-vs-avg winrate (BR is the opponent)...", file=sys.stderr)
+    br_opp = BRSelfOpponent(args.checkpoint, learner.obs_dim, learner.act_dim, label="br-self")
+    r_br = head_to_head(learner, br_opp, **common_kwargs)
+    br_avg_wr = float(r_br.winrate)
+    # The reported winrate is the LEARNER's. BR's winrate vs avg = 1 - learner_winrate.
+    br_winrate = 1.0 - br_avg_wr
+
+    # Metric 2: Symmetric NashConv lower bound.
+    # Without seat-swapping the env's seat assignment is itself randomized
+    # per game, so a single run already mixes seats. The single BR_winrate
+    # therefore approximates the symmetric expectation; doubling its
+    # deviation from 0.5 is the standard NashConv estimate for symmetric
+    # games.
+    nash_conv = 2.0 * (br_winrate - 0.5)
+
+    # Metric 3: per-round-state BR exploitability (uses the binning
+    # already populated by head_to_head).
+    bin_rows = []
+    wins_2d: Dict[Tuple[int, int], int] = r_br.metadata.get("wins_2d", {})
+    losses_2d: Dict[Tuple[int, int], int] = r_br.metadata.get("losses_2d", {})
+    keys = sorted(set(wins_2d) | set(losses_2d))
+    bins_table: Dict[Tuple[int, int], Tuple[float, int]] = {}
+    for k in keys:
+        # learner-perspective wins/losses; flip for BR perspective
+        w = int(wins_2d.get(k, 0))
+        l = int(losses_2d.get(k, 0))
+        tot = w + l
+        if tot == 0:
+            continue
+        learner_wr = w / tot
+        br_wr = 1.0 - learner_wr
+        bins_table[k] = (br_wr, tot)
+
+    # Metric 4: vs frozen-self (current vs prior baseline checkpoint).
+    baseline_wr = None
+    baseline_ngames = 0
+    if args.baseline_checkpoint:
+        print("Running metric 4: vs frozen baseline checkpoint...", file=sys.stderr)
+        snap_opp = SnapshotOpponent(args.baseline_checkpoint, learner.obs_dim, learner.act_dim,
+                                    label=f"snap:{os.path.basename(args.baseline_checkpoint)}")
+        r_snap = head_to_head(learner, snap_opp, **common_kwargs)
+        baseline_wr = float(r_snap.winrate)
+        baseline_ngames = int(r_snap.wins + r_snap.losses)
+
+    # ---- Report ----
+    print()
+    print(f"Exploitability report — {os.path.basename(args.checkpoint)}")
+    print(f"  config: deck={args.deck_size} players={args.n_players} max_cards={args.max_cards}")
+    print(f"  n_games per metric: {args.n_games}; seed: {args.seed}")
+    print()
+    print(f"  [1] BR-vs-avg winrate                  : {br_winrate:.4f}  (learner-as-avg lost {1.0-br_avg_wr:.4f})")
+    print(f"      → exploitability lower bound (sym) : {(br_winrate - 0.5):.4f}")
+    print(f"  [2] NashConv estimate (symmetric)      : {nash_conv:.4f}  (0 = at Nash; >0 = exploitable)")
+    print()
+    print(f"  [3] Per-round-state BR exploitability (cells with ≥10 rounds shown):")
+    print(f"      {'our×opp':>8} {'br_wr':>8} {'n':>6}")
+    for k, (wr, n) in sorted(bins_table.items()):
+        if n >= 10:
+            print(f"      {str(k):>8} {wr:>8.3f} {n:>6}")
+    if baseline_wr is not None:
+        print()
+        print(f"  [4] Current avg policy vs baseline ckpt: {baseline_wr:.4f} over {baseline_ngames} rounds")
+        print(f"      ({os.path.basename(args.baseline_checkpoint)} as opponent)")
+
+    if args.csv_output:
+        os.makedirs(os.path.dirname(args.csv_output) or ".", exist_ok=True)
+        new_file = (not os.path.exists(args.csv_output)) or os.path.getsize(args.csv_output) == 0
+        with open(args.csv_output, "a" if not new_file else "w", newline="") as f:
+            w = csv.writer(f)
+            if new_file:
+                w.writerow(["checkpoint", "metric", "value", "n_games"])
+            ckpt = os.path.basename(args.checkpoint)
+            w.writerow([ckpt, "br_vs_avg_winrate", f"{br_winrate:.6f}", args.n_games])
+            w.writerow([ckpt, "nash_conv_symmetric", f"{nash_conv:.6f}", args.n_games])
+            if baseline_wr is not None:
+                w.writerow([ckpt, "vs_baseline_winrate", f"{baseline_wr:.6f}", baseline_ngames])
+        print(f"\n  Wrote headline CSV: {args.csv_output}")
+
+    if args.bin_output:
+        write_per_bin_csv(args.bin_output, [r_br])
+        print(f"  Wrote per-bin CSV: {args.bin_output}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds CFR-style exploitability metrics so training-time decisions can be driven by the actual NashConv lower bound rather than step counts. Four complementary signals:

1. **BR-vs-avg winrate** — opponent uses the same checkpoint's Q-net as a best-response; learner uses its average policy. Winrate above 0.5 = avg policy is exploitable.
2. **Symmetric NashConv** = \`2 * (BR_winrate - 0.5)\`. 0 = at Nash; >0 = exploitable.
3. **Per-round-state BR exploitability** — re-uses the (our_n_cards, opp_n_cards) binning from PR #56 to localise exploitability to early- vs late-game phases.
4. **Vs frozen-baseline-checkpoint winrate** — sanity that the current avg policy has actually improved over the prior one.

## Files

- \`tools/eval_ladder.py\`: new \`BRSelfOpponent\` class wraps the same checkpoint's Q-net; \`build_opponents\` accepts \`br-self\` and passes through the learner's checkpoint path; help text updated to reference NashConv.
- \`tools/exploitability.py\` (new): stand-alone CLI runner producing all four metrics with optional CSV outputs.

## Test plan
- [x] Smoke-tested \`python -m tools.exploitability --checkpoint <C-5M> --n-games 500 ...\` — reports BR-vs-avg=0.542, NashConv≈0.084. Per-round-state cells populated.
- [x] Old (non-factorized) and new (factorized) checkpoints both load via the saved \`cfg\` field.
- [x] No regression to existing eval_ladder behavior (br-self only added when explicitly requested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)