### PR TITLE
perf: cache hot probability helpers (~3.5x self-play speedup)

### DIFF
--- a/shared/game_utils.py
+++ b/shared/game_utils.py
@@ -13,6 +13,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+@lru_cache(maxsize=8)
 def _build_rule_components(deck_size: int) -> Tuple[int, Dict[str, List[int]], Dict[str, List[int]], Dict[str, int]]:
     if deck_size == RuleValues.DECK_SIZE_DEFAULT:
         vals = 6
@@ -61,8 +62,16 @@ class GameRules:
         self.check_action_id = self.num_actions - 1
 
 
+@lru_cache(maxsize=4096)
+def _get_set_details_cached(action_id: int, deck_size: int) -> Dict[str, object]:
+    return _get_set_details_impl(action_id, deck_size)
+
+
 def get_set_details_from_action_id(action_id: int, deck_size: int = RuleValues.DECK_SIZE_DEFAULT) -> Dict[str, object]:
-    action_id = int(action_id)
+    return _get_set_details_cached(int(action_id), int(deck_size))
+
+
+def _get_set_details_impl(action_id: int, deck_size: int) -> Dict[str, object]:
     vals, straight_types, flush_straight_types, boundaries = _build_rule_components(int(deck_size))
 
     if action_id < boundaries["High card"]:

--- a/shared/probabilities/dynamic_probabilities.py
+++ b/shared/probabilities/dynamic_probabilities.py
@@ -6,6 +6,7 @@ from typing import Iterable, Tuple, NamedTuple
 from shared.game_utils import GameRules, get_set_details_from_action_id
 
 
+@lru_cache(maxsize=4096)
 def binom(n, k):
     if n < k or k < 0:
         return 0


### PR DESCRIPTION
## Summary
- Added `@lru_cache` to three pure helpers identified as hot in cProfile: `binom`, `_build_rule_components`, `get_set_details_from_action_id`.
- All three have tiny unique-input spaces (~20-30 (n,k) pairs for binom, 1-2 deck sizes, ~89 action_ids per deck size) but are called millions of times during `vectorize_obs`.

## Measured impact (cProfile, profile_selfplay 30k env steps, threads=1)
- env+agent steps/sec: **725 → 2560** (+253%)
- `vectorize_obs` cumulative time: **68% → 23%** of total
- `binom`, `_build_rule_components`, `get_set_details_from_action_id`, `_calculate_prob_full_house`, `_calculate_prob_two_pairs`, `_calculate_prob_straight` all drop **out of the top-40 hotspots**

## Safety
- All three helpers are pure functions of small hashable inputs.
- `get_set_details_from_action_id` returns a dict (potentially mutable). Verified all in-tree callers are read-only:
  - `shared/probabilities/dynamic_probabilities.py:237` — only `.get()` / dict access
  - `shared/api/simpleschema_local_manager.py` — pass-through wrapper
  - `gpt_ai/agent.py:19` — read-only
  - `tests/test_game_utils.py` — assertions only

## Test plan
- [x] `python -m unittest tests.test_game_utils tests.test_dynamic_probabilities -v` (10 tests pass)
- [x] Manual cache-info check confirms hits for binom/_build_rule_components/get_set_details
- [x] Sanity: `binom(5,2)==10`, `binom(2,5)==0`, `binom(5,-1)==0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)