### PR TITLE
production_agent: variant-aware model routing

### DIFF
--- a/nfsp_ai/agent.py
+++ b/nfsp_ai/agent.py
@@ -1899,12 +1899,14 @@ class NFSPAgent:
 
     def export_inference(self, path: str):
         payload = {
-            "version": 1,
+            "version": 2,
             "obs_dim": int(self.obs_dim),
             "act_dim": int(self.act_dim),
             "q": self.q.state_dict(),
             "pi": self.pi.state_dict(),
             "cfg": {
+                "hidden": int(self.cfg.hidden),
+                "factorize_action_head": bool(getattr(self.cfg, "factorize_action_head", False)),
                 "gamma": float(self.cfg.gamma),
                 "anticipatory_eta": float(self.cfg.anticipatory_eta),
                 "eps_start": float(self.cfg.eps_start),

--- a/nfsp_ai/agent.py
+++ b/nfsp_ai/agent.py
@@ -1169,7 +1169,9 @@ class NFSPAgent:
         is_br: bool,
         *,
         actor=None,          # <-- seat index or nickname of the actor for this step
-        loser=None           # <-- loser id ONLY on terminal step (None otherwise)
+        loser=None,          # <-- loser id ONLY on terminal step (None otherwise)
+        actor_team=None,     # <-- actor's team id (None in solo mode); per-step
+        loser_team=None,     # <-- loser's team id (None in solo mode); terminal-only
     ):
         if not hasattr(self, "_nstep_queue"):
             raise ValueError("_nstep_queue not in self!")
@@ -1215,7 +1217,9 @@ class NFSPAgent:
             "done":  bool(done),
             "is_br": bool(is_br),
             "actor": actor,                  # REQUIRED for all steps (2–8 players)
-            "loser": loser if done else None # ONLY present on terminal step
+            "loser": loser if done else None, # ONLY present on terminal step
+            "actor_team": actor_team,        # team id for THIS step's actor (None in solo)
+            "loser_team": loser_team if done else None,  # team id of the round's loser
         }
         self._nstep_queue.append(entry)
 
@@ -1265,6 +1269,7 @@ class NFSPAgent:
         # Identify terminal and loser
         term = seq[-1]
         loser_id = term.get("loser", None)
+        loser_team = term.get("loser_team", None)
         total_steps = len(seq)
         gamma = float(self.cfg.gamma)
 
@@ -1291,7 +1296,15 @@ class NFSPAgent:
                 raise ValueError(
                     f"actor and/or loser info missing! actor: {actor_id!r}, loser: {loser_id!r}"
                 )
-            sign = -1.0 if actor_id == loser_id else +1.0
+            # Team-aware credit: in team mode, sign is -1 if this step's
+            # actor is on the same team as the round's loser (team got
+            # dinged) and +1 otherwise. Falls back to individual identity
+            # when team info is absent (solo mode or older trajectories).
+            actor_team = step.get("actor_team", None)
+            if actor_team is not None and loser_team is not None:
+                sign = -1.0 if actor_team == loser_team else +1.0
+            else:
+                sign = -1.0 if actor_id == loser_id else +1.0
             R = sign * g
 
             if not step.get("is_br", False):
@@ -1515,12 +1528,16 @@ class NFSPAgent:
 
             # Extract actor every step; loser only on terminal
             actor = info_dict.get("actor", None) if info_dict else None
+            actor_team = info_dict.get("actor_team", None) if info_dict else None
             loser = None
+            loser_team = None
             rr = info_dict.get("round_result")
             if rr is not None:
                 loser = rr.get("loser", None)
+                loser_team = rr.get("loser_team", None)
 
-            # Pass actor/loser so _flush_nstep can distribute rewards.
+            # Pass actor/loser (and their teams) so _flush_nstep can
+            # distribute rewards correctly in both solo and team modes.
             # Skip storage when the frozen-snapshot opponent acted: those
             # transitions would teach the learner to mimic its past self
             # (a fixed point) and pollute the n-step shaping with off-policy
@@ -1528,7 +1545,8 @@ class NFSPAgent:
             if env.game["round_number"] >= self.cfg.min_round and not is_frozen_acting:
                 self._store_transition(
                     obs, mask, action, reward, nobs, nmask, done, is_br=use_br,
-                    actor=actor, loser=loser
+                    actor=actor, loser=loser,
+                    actor_team=actor_team, loser_team=loser_team,
                 )
 
             # Ensure n-step buffer flushes at terminals (round end)
@@ -1660,10 +1678,22 @@ class NFSPAgent:
             # Episode handling
             if done:
                 self._flush_nstep(force=True)
+                # Team-aware metric: when teams are set, score from the
+                # ref's TEAM perspective (loser-on-our-team = loss).
+                # Falls back to individual when team info is absent.
                 if loser:
-                    recent_winloss_results.append(loser!=env._ref_nick)
-                if loser:
-                    recent_rewards.append(1 if loser!=env._ref_nick else -1)
+                    ref_nick = env._ref_nick
+                    ref_team = None
+                    for _p in (env.game.get("players") or []):
+                        if _p.get("nickname") == ref_nick:
+                            ref_team = _p.get("team")
+                            break
+                    if ref_team is not None and loser_team is not None:
+                        is_win = (loser_team != ref_team)
+                    else:
+                        is_win = (loser != ref_nick)
+                    recent_winloss_results.append(is_win)
+                    recent_rewards.append(1 if is_win else -1)
                 recent_lens.append(ep_len)
                 ep_reward, ep_len = 0.0, 0
                 obs, mask, pid = env.reset()

--- a/nfsp_ai/nfsp_run_local.py
+++ b/nfsp_ai/nfsp_run_local.py
@@ -57,6 +57,7 @@ def _compute_obs_dim(
         + 1  # common jokers
         + card_dim
         + MAX_PLAYERS
+        + MAX_PLAYERS  # per-slot team flag: +1 teammate / -1 opponent / 0 none
         + 1  # round scaling
         + history_dim
         + 1  # last bet prob
@@ -428,6 +429,71 @@ def _legal_action_mask(game: dict, spec: DeckSpec, pub_prior: list) -> torch.Ten
             mask[next_min:check] = 1.0
         # CHECK legal once at least one bet has happened.
         mask[check] = 1.0
+
+    # ===== Team-aware constraints =====
+    # Rule 1: never check a teammate. CHECK is illegal if the most-recent
+    # bettor is on the actor's team. (CHECK calls the *last bet*, so the
+    # check-target is the last non-check actor in history.)
+    # Rule 2: never force a teammate to check. If the next-in-turn is on
+    # the actor's team, the actor's bet must leave at least one legal
+    # raise above. (One-step lookahead; deeper consecutive-teammate
+    # cascades are rare and not enforced here.)
+    players = game.get("players") or []
+    if players:
+        actor_nick = game.get("cp_nickname")
+        actor_team = None
+        for p in players:
+            if p.get("nickname") == actor_nick:
+                actor_team = p.get("team")
+                break
+        if actor_team is not None:
+            check_legal_pre = bool(mask[check])
+            # Rule 1: forbid CHECK if last bettor is on actor's team.
+            if hist:
+                last_bettor_nick = None
+                for ev in reversed(hist):
+                    try:
+                        aid = int((ev or {}).get("action_id", -1))
+                    except Exception:
+                        continue
+                    if 0 <= aid < check:
+                        last_bettor_nick = (ev or {}).get("player")
+                        break
+                if last_bettor_nick is not None:
+                    last_team = None
+                    for p in players:
+                        if p.get("nickname") == last_bettor_nick:
+                            last_team = p.get("team")
+                            break
+                    if last_team is not None and last_team == actor_team:
+                        mask[check] = 0.0
+            # Rule 2: if next-in-turn is a teammate, forbid the
+            # top-of-ladder bet (so the teammate has at least one legal
+            # raise under rule 1). Skip when that bet is the *only* legal
+            # raise — relaxing rule 2 is preferable to zeroing the mask.
+            actor_idx = None
+            for i, p in enumerate(players):
+                if p.get("nickname") == actor_nick:
+                    actor_idx = i
+                    break
+            if actor_idx is not None and check >= 1:
+                n = len(players)
+                next_team = None
+                for offset in range(1, n + 1):
+                    cand = players[(actor_idx + offset) % n]
+                    if int(cand.get("n_cards", 0)) > 0:
+                        next_team = cand.get("team")
+                        break
+                if next_team is not None and next_team == actor_team:
+                    legal_raises_above = int(mask[:check].sum().item()) if hasattr(mask, "sum") else int(mask[:check].sum())
+                    if legal_raises_above >= 2:
+                        mask[check - 1] = 0.0
+            # Fallback: if team rules zeroed the mask, restore CHECK
+            # (rule 1 yields). The actor takes the immediate -1 rather
+            # than crashing the env. Self-play exploration occasionally
+            # walks into this corner.
+            if not mask.any() and check_legal_pre:
+                mask[check] = 1.0
     return torch.from_numpy(mask)
 
 
@@ -652,12 +718,29 @@ def vectorize_obs(
         slot_order += [None] * (MAX_PLAYERS - len(slot_order))
     ordered_counts = np.zeros((MAX_PLAYERS,), dtype=np.float32)
     for slot_idx in range(min(MAX_PLAYERS, len(slot_order))):
-        nick = slot_order[slot_idx] if slot_idx < len(slot_order) else None
-        if nick is None:
+        slot_nick = slot_order[slot_idx] if slot_idx < len(slot_order) else None
+        if slot_nick is None:
             ordered_counts[slot_idx] = 0.0
         else:
-            ordered_counts[slot_idx] = float(counts_map.get(nick, 0))
+            ordered_counts[slot_idx] = float(counts_map.get(slot_nick, 0))
     obs[idx:idx + MAX_PLAYERS] = ordered_counts
+    idx += MAX_PLAYERS
+
+    # Per-slot team flag (rotated to actor at slot 0): +1 teammate, -1
+    # opponent, 0 if no player in slot or game is solo (no team mode).
+    team_map = {p.get("nickname"): p.get("team") for p in players}
+    actor_team = team_map.get(game.get("cp_nickname"))
+    team_flags = np.zeros((MAX_PLAYERS,), dtype=np.float32)
+    if actor_team is not None:
+        for slot_idx in range(min(MAX_PLAYERS, len(slot_order))):
+            slot_nick = slot_order[slot_idx] if slot_idx < len(slot_order) else None
+            if slot_nick is None:
+                continue
+            other_team = team_map.get(slot_nick)
+            if other_team is None:
+                continue
+            team_flags[slot_idx] = 1.0 if other_team == actor_team else -1.0
+    obs[idx:idx + MAX_PLAYERS] = team_flags
     idx += MAX_PLAYERS
 
     # Round scaling
@@ -1066,6 +1149,8 @@ class MyEnv:
                 "ref": ref,
                 "before_counts": before_counts,
                 "after_counts": after_counts,
+                "actor_team": actor_team,
+                "loser_team": loser_team,
             }
             history_for_log = history_before
 
@@ -1097,11 +1182,22 @@ class MyEnv:
         assert done or self.rounds_since_reset < MAX_ROUNDS
 
         self._last_obs, self._last_mask = obs, mask
+        # Compute actor's team for THIS step (not the round terminal).
+        # Needed by the n-step credit shaping so per-step credit can be
+        # team-aware: sign = -1 if actor's team == loser's team, else +1.
+        # In solo mode both fields are None and the agent falls back to
+        # individual identity comparison.
+        step_actor_team = None
+        for p in (self.game.get("players") or []):
+            if p.get("nickname") == actor_nick:
+                step_actor_team = p.get("team")
+                break
         info = {
             "next_pid": pid,
             "illegal": 0,
             "action": action_int,
             "actor": actor_nick,
+            "actor_team": step_actor_team,
             "history": history_for_log,
             "round_result": round_result,
             "reward": float(reward),

--- a/nfsp_ai/nfsp_run_local.py
+++ b/nfsp_ai/nfsp_run_local.py
@@ -773,16 +773,21 @@ class MyEnv:
         pick_jokers_in_range: bool = False,
         pick_blanks_in_range: bool = False,
         pick_common_cards_in_range: bool = False,
+        pick_n_teams_in_range: bool = False,
+        n_teams: int = 0,
         randomize_initial_hands: bool = False,
     ):
         if n_agents < 2 or n_agents > 8:
             raise ValueError("n_agents must be in [2, 8]")
+        if n_teams < 0:
+            raise ValueError("n_teams must be >= 0")
 
         self.n_agents = n_agents
         self.max_cards = max_cards
         self.joker_cap = max(0, int(jokers))
         self.blank_cap = max(0, int(blanks))
         self.common_card_cap = max(0, int(common_cards))
+        self.n_teams_cap = max(0, int(n_teams))
         self.rules = {
             "deck_size": int(deck_size),
             "jokers": self.joker_cap,
@@ -810,6 +815,7 @@ class MyEnv:
         self.pick_jokers_in_range = pick_jokers_in_range
         self.pick_blanks_in_range = pick_blanks_in_range
         self.pick_common_cards_in_range = pick_common_cards_in_range
+        self.pick_n_teams_in_range = pick_n_teams_in_range
         self.randomize_initial_hands = bool(randomize_initial_hands)
 
         self.game: Dict = {}
@@ -871,6 +877,20 @@ class MyEnv:
         common_cards = self.common_card_cap
         if self.pick_common_cards_in_range:
             common_cards = random.randint(0, self.common_card_cap)
+        # n_teams: 0 = solo (no team mode); >=2 = team game with that
+        # many teams. With pick_n_teams_in_range, sample uniformly from
+        # {0, 2, ..., n_teams_cap} per game. Skip values that exceed
+        # n_agents (need at least one player per team).
+        if self.n_teams_cap >= 2:
+            if self.pick_n_teams_in_range:
+                # Choose 0 (solo) or any valid team count up to the cap
+                # that is also ≤ n_agents.
+                choices = [0] + [t for t in range(2, self.n_teams_cap + 1) if t <= n_agents]
+                n_teams = random.choice(choices)
+            else:
+                n_teams = self.n_teams_cap if self.n_teams_cap <= n_agents else 0
+        else:
+            n_teams = 0
         # Random-initial-hand-size scenario sampling. By default Blef games
         # start with every player holding exactly 1 card and accumulate as
         # players lose rounds. When `--randomize-initial-hands` is set, every
@@ -892,6 +912,7 @@ class MyEnv:
             jokers=jokers,
             blanks=blanks,
             common_cards=common_cards,
+            n_teams=(n_teams if n_teams >= 2 else None),
             verbose=self.verbose,
             init_card_dist=init_card_dist,
         )
@@ -1017,10 +1038,24 @@ class MyEnv:
 
             loser = loser_candidates[0] if loser_candidates else None
             ref = self._ref_nick
+            # Team-aware reward: a round-loss by anyone on the actor's
+            # team counts as -1 (the team got dinged); a round-loss by
+            # an opponent counts as +1. Falls back to the individual
+            # actor-vs-loser comparison when teams aren't set (solo
+            # mode) or in mixed games where the actor has no team.
+            actor_team = None
+            loser_team = None
+            for p in (self.game.get("players") or []):
+                if p.get("nickname") == actor_nick:
+                    actor_team = p.get("team")
+                if loser is not None and p.get("nickname") == loser:
+                    loser_team = p.get("team")
             if ref is None:
                 reward = 0.0
             elif loser is None:
                 reward = 0.0
+            elif actor_team is not None and loser_team is not None:
+                reward = -1.0 if loser_team == actor_team else 1.0
             elif loser == actor_nick:
                 reward = -1.0
             else:
@@ -1055,8 +1090,10 @@ class MyEnv:
                 done_reason = "ref_eliminated"
                 self._round_boundary_pending = False  # start a new game on reset
 
-        # safety cap to avoid non-terminating matches
-        MAX_ROUNDS = 50
+        # safety cap to avoid non-terminating matches. Solo games rarely
+        # exceed ~30 rounds. Team games can: with 8p in 4v4 and max_cards=11,
+        # the worst case is 8*11=88 rounds. Cap conservatively.
+        MAX_ROUNDS = 200
         assert done or self.rounds_since_reset < MAX_ROUNDS
 
         self._last_obs, self._last_mask = obs, mask
@@ -1178,6 +1215,23 @@ def main():
         dest="pick_blanks_in_range",
         action="store_true",
         help="Sample the number of blanks uniformly from [0, --blanks] for each new game.",
+    )
+    parser.add_argument(
+        "--n-teams",
+        dest="n_teams",
+        type=int,
+        default=0,
+        help=(
+            "Number of teams for team-mode games (0 = solo / no teams). "
+            "If --pick-n-teams-in-range is set, sample uniformly from "
+            "{0, 2, ..., n_teams} per game (skipping values > n_agents)."
+        ),
+    )
+    parser.add_argument(
+        "--pick-n-teams-in-range",
+        dest="pick_n_teams_in_range",
+        action="store_true",
+        help="Sample the number of teams uniformly from {0, 2, ..., --n-teams} for each new game.",
     )
     parser.add_argument(
         "--pick-common-cards-in-range",
@@ -1581,6 +1635,8 @@ def main():
         pick_jokers_in_range=args.pick_jokers_in_range,
         pick_blanks_in_range=args.pick_blanks_in_range,
         pick_common_cards_in_range=args.pick_common_cards_in_range,
+        n_teams=getattr(args, "n_teams", 0),
+        pick_n_teams_in_range=getattr(args, "pick_n_teams_in_range", False),
         randomize_initial_hands=args.randomize_initial_hands,
     )
     obs0, mask0, _ = env.reset()
@@ -1644,6 +1700,8 @@ def main():
         pick_jokers_in_range=args.pick_jokers_in_range,
         pick_blanks_in_range=args.pick_blanks_in_range,
         pick_common_cards_in_range=args.pick_common_cards_in_range,
+        n_teams=getattr(args, "n_teams", 0),
+        pick_n_teams_in_range=getattr(args, "pick_n_teams_in_range", False),
         # Eval env intentionally does NOT use randomize_initial_hands: the RIC
         # curriculum is a training-time intervention; eval scores the agent on
         # natural-distribution starts (all players begin with 1 card).
@@ -1669,6 +1727,8 @@ def main():
             pick_jokers_in_range=args.pick_jokers_in_range,
             pick_blanks_in_range=args.pick_blanks_in_range,
             pick_common_cards_in_range=args.pick_common_cards_in_range,
+        n_teams=getattr(args, "n_teams", 0),
+        pick_n_teams_in_range=getattr(args, "pick_n_teams_in_range", False),
         )
         print(
             "EVALUATION (eval-only mode):\n"

--- a/nfsp_ai/production_agent.py
+++ b/nfsp_ai/production_agent.py
@@ -8,7 +8,9 @@ alongside optional card/history embedding artifacts.  It exposes a single helper
 
 from __future__ import annotations
 
+import glob
 import os
+import re
 from dataclasses import replace
 from functools import lru_cache
 from typing import Optional, Tuple
@@ -39,27 +41,118 @@ DEFAULT_DEVICE = os.environ.get("NFSP_DEVICE", "cpu")
 DEFAULT_GREEDY = os.environ.get("NFSP_GREEDY", "1") not in {"0", "false", "False"}
 
 
-def _resolve_model_paths(path: Optional[str]) -> list[str]:
-    candidates: list[str] = []
+# ---------------------------------------------------------------------------
+# Variant-aware model routing
+# ---------------------------------------------------------------------------
+#
+# Naming convention for inference artifacts:
+#
+#     artifacts/nfsp_inference_<deck>_<variant>.pt   (preferred)
+#     artifacts/nfsp_inference_<deck>.pt              (legacy fallback)
+#
+# `<deck>` is "24" or "32"; `<variant>` is one of:
+#
+#     "1v1"   — exactly two players, jokers=blanks=common_cards=0, no teams
+#     "multi" — anything that isn't 1v1 (multi-player, jokers, blanks,
+#               common cards, or any combination)
+#     "team"  — reserved for future team / partnership game variants
+#
+# Multiple checkpoints can coexist; at inference, `_routing_keys` produces
+# a priority chain (most specific first). The first key with a loaded
+# agent wins. The bare `<deck>` key acts as a final fallback so legacy
+# deployments without variant-specific files keep working unchanged.
+
+_INFERENCE_FILENAME_RE = re.compile(
+    r"^nfsp_inference_(?P<deck>24|32)(?:_(?P<variant>[A-Za-z0-9]+))?\.pt$"
+)
+_KNOWN_VARIANTS = ("1v1", "multi", "team")
+
+
+def _model_key_from_filename(path: str) -> Optional[str]:
+    """Map an inference file path to its routing key.
+
+    Returns None if the filename doesn't match the convention.
+    """
+    name = os.path.basename(path)
+    m = _INFERENCE_FILENAME_RE.match(name)
+    if not m:
+        return None
+    deck = m.group("deck")
+    variant = m.group("variant")
+    if variant is None:
+        return deck  # legacy
+    return f"{deck}_{variant}"
+
+
+def _routing_keys(rules: dict, n_players: int) -> list[str]:
+    """Return preferred routing keys, most-specific first.
+
+    The caller walks this list and picks the first key with a loaded
+    agent. Always ends with the bare `<deck>` legacy key so a
+    single-model deployment continues to work.
+    """
+    deck = int(rules.get("deck_size", 24))
+    is_team = bool(rules.get("teams", False))
+    j = int(rules.get("jokers", 0))
+    b = int(rules.get("blanks", 0))
+    cc = int(rules.get("common_cards", 0))
+    is_1v1 = (n_players == 2 and j == 0 and b == 0 and cc == 0 and not is_team)
+
+    keys: list[str] = []
+    if is_team:
+        keys.append(f"{deck}_team")
+    if is_1v1:
+        keys.append(f"{deck}_1v1")
+    keys.append(f"{deck}_multi")
+    keys.append(str(deck))  # legacy fallback
+    # de-dupe while preserving order
+    out: list[str] = []
     seen: set[str] = set()
-    if path:
-        candidates.append(path)
-    else:
-        candidates.extend(
-            [
-                "artifacts/nfsp_inference_32.pt",
-                "artifacts/nfsp_inference_24.pt",
-                DEFAULT_MODEL_PATH,
-            ]
-        )
-    resolved: list[str] = []
-    for cand in candidates:
-        if not cand or cand in seen:
+    for k in keys:
+        if k in seen:
             continue
-        seen.add(cand)
-        if os.path.exists(cand):
-            resolved.append(cand)
-    return resolved
+        seen.add(k)
+        out.append(k)
+    return out
+
+
+def _resolve_model_paths(path: Optional[str]) -> dict[str, str]:
+    """Discover inference checkpoints. Returns {routing_key: path}.
+
+    If `path` is given, treat it as a single explicit checkpoint and
+    derive its key from the filename (or use a synthesised key when the
+    filename is non-standard).
+    """
+    out: dict[str, str] = {}
+    if path:
+        if not os.path.exists(path):
+            return out
+        key = _model_key_from_filename(path)
+        if key is None:
+            # Non-standard filename: store under a synthetic deck-only key
+            # using the act_dim probe at load time. We cannot infer it from
+            # the filename, so store under "explicit" and let the loader
+            # rewrite the key.
+            key = "explicit"
+        out[key] = path
+        return out
+
+    # Discovery: scan artifacts/ for files matching the naming convention.
+    # Search both relative ("artifacts/...") and an explicit absolute env
+    # override (DEFAULT_MODEL_PATH) so deployments can point at a custom
+    # directory.
+    search_globs = ["artifacts/nfsp_inference_*.pt"]
+    extra_dir = os.path.dirname(DEFAULT_MODEL_PATH) if DEFAULT_MODEL_PATH else ""
+    if extra_dir and extra_dir not in {"", "artifacts"}:
+        search_globs.append(os.path.join(extra_dir, "nfsp_inference_*.pt"))
+    for pattern in search_globs:
+        for cand in glob.glob(pattern):
+            key = _model_key_from_filename(cand)
+            if key is None:
+                continue
+            # First file wins per key; prefer the order produced by glob (alphabetical).
+            out.setdefault(key, cand)
+    return out
 
 
 def _load_card_embedding_map(path: Optional[str], device: torch.device) -> dict[int, CardEmbeddingRuntime]:
@@ -144,9 +237,11 @@ class NFSPProductionAgent:
         self.device = torch.device(device)
         self.greedy = bool(greedy)
 
-        self.agents: dict[int, NFSPAgent] = {}
-        self.model_sources: dict[int, str] = {}
-        for cand in _resolve_model_paths(model_path):
+        # agents: routing-key -> NFSPAgent
+        # routing-key examples: "24" (legacy), "24_1v1", "24_multi", "32_team"
+        self.agents: dict[str, NFSPAgent] = {}
+        self.model_sources: dict[str, str] = {}
+        for key, cand in _resolve_model_paths(model_path).items():
             ckpt = torch.load(cand, map_location=self.device)
             act_dim = int(ckpt.get("act_dim", 0))
             if act_dim == GameRules(24).num_actions:
@@ -158,16 +253,21 @@ class NFSPProductionAgent:
                     f"Inference checkpoint '{cand}' has unsupported act_dim={act_dim}; "
                     "expected 89 (24-card) or 141 (32-card)."
                 )
-            if deck_size in self.agents:
+            # If the filename was non-standard ("explicit"), rewrite the
+            # key from the probed deck size so the legacy fallback still
+            # kicks in.
+            if key == "explicit":
+                key = str(deck_size)
+            if key in self.agents:
                 continue
             agent = self._build_agent_from_checkpoint(ckpt)
-            self.agents[deck_size] = agent
-            self.model_sources[deck_size] = cand
+            self.agents[key] = agent
+            self.model_sources[key] = cand
 
         if not self.agents:
             raise FileNotFoundError(
                 "No inference checkpoints found. Provide NFSP_MODEL_PATH or place "
-                "artifacts/nfsp_inference_<deck>.pt alongside the Lambda package."
+                "artifacts/nfsp_inference_<deck>[_<variant>].pt alongside the Lambda package."
             )
 
         self.card_embeddings = _load_card_embedding_map(card_embedding_path, self.device)
@@ -184,9 +284,22 @@ class NFSPProductionAgent:
             )
         ckpt_cfg = checkpoint.get("cfg", {})
         base_cfg = NFSPConfig()
+        # Hidden width: prefer the value saved in cfg, but fall back to
+        # detecting it from the Q-net state dict (older exports omitted
+        # `hidden` from cfg, so checkpoints with hidden != default would
+        # mismatch on load_state_dict).
+        hidden = ckpt_cfg.get("hidden")
+        if hidden is None:
+            q_sd = checkpoint.get("q", {})
+            for key in ("net.0.weight", "trunk.0.weight"):
+                if key in q_sd:
+                    hidden = int(q_sd[key].shape[0])
+                    break
+            if hidden is None:
+                hidden = base_cfg.hidden
         cfg = replace(
             base_cfg,
-            hidden=ckpt_cfg.get("hidden", base_cfg.hidden),
+            hidden=int(hidden),
             anticipatory_eta=ckpt_cfg.get("anticipatory_eta", base_cfg.anticipatory_eta),
         )
         cfg.rl_capacity = 1
@@ -220,14 +333,25 @@ class NFSPProductionAgent:
         if not cp:
             raise ValueError("Game state missing 'cp_nickname'")
 
-        deck_size = int(game_state.get("rules", {}).get("deck_size", 24))
-        agent = self.agents.get(deck_size)
+        rules = game_state.get("rules", {}) or {}
+        deck_size = int(rules.get("deck_size", 24))
+        n_players = len(game_state.get("players", []) or [])
+        keys = _routing_keys(rules, n_players)
+        agent = None
+        chosen_key = None
+        for key in keys:
+            agent = self.agents.get(key)
+            if agent is not None:
+                chosen_key = key
+                break
         if agent is None:
-            available = ", ".join(str(k) for k in sorted(self.agents.keys()))
+            available = ", ".join(sorted(self.agents.keys()))
             raise RuntimeError(
-                f"No NFSP checkpoint loaded for deck size {deck_size}. "
-                f"Available decks: {available or 'none'}."
+                f"No NFSP checkpoint loaded for deck={deck_size} n={n_players}. "
+                f"Tried keys: {keys}. Available: {available or 'none'}."
             )
+        # Embeddings remain keyed by deck size; variant doesn't change
+        # the card / history vocabulary.
         card_embedding = self.card_embeddings.get(deck_size)
         history_embedding = self.history_embeddings.get(deck_size)
         spec = _deck_spec_from_game(

--- a/nfsp_ai/production_agent.py
+++ b/nfsp_ai/production_agent.py
@@ -84,8 +84,14 @@ def _model_key_from_filename(path: str) -> Optional[str]:
     return f"{deck}_{variant}"
 
 
-def _routing_keys(rules: dict, n_players: int, players: Optional[list] = None) -> list[str]:
+def _routing_keys(rules: dict, n_active: int, players: Optional[list] = None) -> list[str]:
     """Return preferred routing keys, most-specific first.
+
+    Routes by *active* player count (players with cards remaining), not
+    seated count. A 4-player game collapsed to 2 active players is
+    structurally a 1v1 subtree and routes to the 1v1 specialist —
+    provided the obs is canonicalized to drop eliminated seats before
+    inference (see `_canonicalize_to_active`).
 
     The caller walks this list and picks the first key with a loaded
     agent. Always ends with the bare `<deck>` legacy key so a
@@ -103,7 +109,7 @@ def _routing_keys(rules: dict, n_players: int, players: Optional[list] = None) -
     j = int(rules.get("jokers", 0))
     b = int(rules.get("blanks", 0))
     cc = int(rules.get("common_cards", 0))
-    is_1v1 = (n_players == 2 and j == 0 and b == 0 and cc == 0 and not is_team)
+    is_1v1 = (n_active == 2 and j == 0 and b == 0 and cc == 0 and not is_team)
 
     keys: list[str] = []
     if is_team:
@@ -120,6 +126,27 @@ def _routing_keys(rules: dict, n_players: int, players: Optional[list] = None) -
             continue
         seen.add(k)
         out.append(k)
+    return out
+
+
+def _canonicalize_to_active(game_state: dict) -> dict:
+    """Return a shallow copy of `game_state` with eliminated players removed.
+
+    Players with `n_cards == 0` are dropped from the players list so the
+    seat block in `vectorize_obs` matches a fresh game at the same
+    active-player count. The 1v1 specialist trained without
+    eliminations sees in-distribution input on collapsed games.
+
+    History is round-scoped and only contains active-player events
+    within the current round (eliminations happen at round boundaries),
+    so it does not need filtering.
+    """
+    players = game_state.get("players") or []
+    active = [p for p in players if int(p.get("n_cards", 0)) > 0]
+    if len(active) == len(players):
+        return game_state
+    out = dict(game_state)
+    out["players"] = active
     return out
 
 
@@ -343,8 +370,9 @@ class NFSPProductionAgent:
         rules = game_state.get("rules", {}) or {}
         deck_size = int(rules.get("deck_size", 24))
         players = game_state.get("players", []) or []
-        n_players = len(players)
-        keys = _routing_keys(rules, n_players, players=players)
+        n_seated = len(players)
+        n_active = sum(1 for p in players if int(p.get("n_cards", 0)) > 0)
+        keys = _routing_keys(rules, n_active, players=players)
         agent = None
         chosen_key = None
         for key in keys:
@@ -355,9 +383,17 @@ class NFSPProductionAgent:
         if agent is None:
             available = ", ".join(sorted(self.agents.keys()))
             raise RuntimeError(
-                f"No NFSP checkpoint loaded for deck={deck_size} n={n_players}. "
+                f"No NFSP checkpoint loaded for deck={deck_size} "
+                f"n_active={n_active} (seated={n_seated}). "
                 f"Tried keys: {keys}. Available: {available or 'none'}."
             )
+        # The 1v1 specialist trained without eliminations; canonicalize
+        # the state (drop eliminated seats) so the obs matches its
+        # training distribution. multi/team specialists trained on
+        # games that include eliminations and expect the seat block
+        # to retain eliminated slots, so they pass through unchanged.
+        if chosen_key and chosen_key.endswith("_1v1") and n_active < n_seated:
+            game_state = _canonicalize_to_active(game_state)
         # Embeddings remain keyed by deck size; variant doesn't change
         # the card / history vocabulary.
         card_embedding = self.card_embeddings.get(deck_size)

--- a/nfsp_ai/production_agent.py
+++ b/nfsp_ai/production_agent.py
@@ -84,15 +84,22 @@ def _model_key_from_filename(path: str) -> Optional[str]:
     return f"{deck}_{variant}"
 
 
-def _routing_keys(rules: dict, n_players: int) -> list[str]:
+def _routing_keys(rules: dict, n_players: int, players: Optional[list] = None) -> list[str]:
     """Return preferred routing keys, most-specific first.
 
     The caller walks this list and picks the first key with a loaded
     agent. Always ends with the bare `<deck>` legacy key so a
     single-model deployment continues to work.
+
+    Team mode is detected by inspecting `players[*].team` (the engine
+    schema). A players list with any non-None team value means team
+    mode. The legacy `rules.teams` flag is also honoured for callers
+    that pre-compute it.
     """
     deck = int(rules.get("deck_size", 24))
     is_team = bool(rules.get("teams", False))
+    if not is_team and players:
+        is_team = any(p.get("team") is not None for p in players)
     j = int(rules.get("jokers", 0))
     b = int(rules.get("blanks", 0))
     cc = int(rules.get("common_cards", 0))
@@ -335,8 +342,9 @@ class NFSPProductionAgent:
 
         rules = game_state.get("rules", {}) or {}
         deck_size = int(rules.get("deck_size", 24))
-        n_players = len(game_state.get("players", []) or [])
-        keys = _routing_keys(rules, n_players)
+        players = game_state.get("players", []) or []
+        n_players = len(players)
+        keys = _routing_keys(rules, n_players, players=players)
         agent = None
         chosen_key = None
         for key in keys:

--- a/nfsp_ai/production_agent.py
+++ b/nfsp_ai/production_agent.py
@@ -322,18 +322,25 @@ class NFSPProductionAgent:
         # detecting it from the Q-net state dict (older exports omitted
         # `hidden` from cfg, so checkpoints with hidden != default would
         # mismatch on load_state_dict).
+        q_sd = checkpoint.get("q", {})
         hidden = ckpt_cfg.get("hidden")
         if hidden is None:
-            q_sd = checkpoint.get("q", {})
             for key in ("net.0.weight", "trunk.0.weight"):
                 if key in q_sd:
                     hidden = int(q_sd[key].shape[0])
                     break
             if hidden is None:
                 hidden = base_cfg.hidden
+        # Factorized-head Q-net (and matching policy net) use `trunk.*` /
+        # `bet_head.*` / `check_head.*` keys; the plain net uses `net.*`.
+        # Prefer the cfg flag, then fall back to state-dict shape.
+        factorize = ckpt_cfg.get("factorize_action_head")
+        if factorize is None:
+            factorize = "trunk.0.weight" in q_sd
         cfg = replace(
             base_cfg,
             hidden=int(hidden),
+            factorize_action_head=bool(factorize),
             anticipatory_eta=ckpt_cfg.get("anticipatory_eta", base_cfg.anticipatory_eta),
         )
         cfg.rl_capacity = 1

--- a/shared/api/simpleschema_local_manager.py
+++ b/shared/api/simpleschema_local_manager.py
@@ -232,6 +232,27 @@ def arrange_players(players):
 
     return players
 
+def _assign_teams(n_agents, n_teams):
+    """Partition n_agents into n_teams as evenly as possible, then shuffle.
+
+    Returns a list of length n_agents with team ids (1..n_teams). Returns
+    None for every player if n_teams < 2 (no team mode).
+    """
+    if n_teams is None or n_teams < 2:
+        return [None] * n_agents
+    if n_teams > n_agents:
+        raise ValueError(f"n_teams ({n_teams}) > n_agents ({n_agents})")
+    base, rem = divmod(n_agents, n_teams)
+    assignments = []
+    for t in range(1, n_teams + 1):
+        size = base + (1 if (t - 1) < rem else 0)
+        assignments.extend([t] * size)
+    # Shuffle so seat order doesn't trivially encode team.
+    from random import shuffle as _shuffle
+    _shuffle(assignments)
+    return assignments
+
+
 def create_game(
     n_agents,
     deck_size=DEFAULT_DECK_SIZE,
@@ -239,6 +260,7 @@ def create_game(
     jokers=0,
     blanks=0,
     common_cards=0,
+    n_teams=None,
     verbose=False,
     init_card_dist=None,
 ):
@@ -246,16 +268,22 @@ def create_game(
         raise ValueError("n_agents < 2")
     if n_agents > 8:
         raise ValueError("n_agents > 8")
+    if n_teams is not None and n_teams >= 2 and n_agents < n_teams:
+        raise ValueError(f"need at least n_teams ({n_teams}) players")
+    teams = _assign_teams(n_agents, n_teams)
     game_uuid = str(uuid.uuid4())
     if init_card_dist is None:
-        players = [{"nickname": str(i), "n_cards": 1} for i in range(n_agents)]
+        players = [
+            {"nickname": str(i), "n_cards": 1, "team": teams[i]}
+            for i in range(n_agents)
+        ]
     else:
         if len(init_card_dist) != n_agents:
             raise ValueError(
                 f"init_card_dist length {len(init_card_dist)} must equal n_agents {n_agents}"
             )
         players = [
-            {"nickname": str(i), "n_cards": int(max(1, init_card_dist[i]))}
+            {"nickname": str(i), "n_cards": int(max(1, init_card_dist[i])), "team": teams[i]}
             for i in range(n_agents)
         ]
     if len(players) > 2:
@@ -331,8 +359,17 @@ def handle_check(game, save_dir="games"):
     # Elimination if exceeding max_cards
     if losing_player["n_cards"] > game["max_cards"]:
         losing_player["n_cards"] = 0
-        # Check if game is finished
-        if sum(p["n_cards"] > 0 for p in game["players"]) == 1:
+        # Check if game is finished — solo (last player standing) OR team
+        # mode (all surviving players share a non-None team id).
+        active = [p for p in game["players"] if p["n_cards"] > 0]
+        finished = False
+        if len(active) <= 1:
+            finished = True
+        elif len(active) > 1:
+            first_team = active[0].get("team")
+            if first_team is not None and all(p.get("team") == first_team for p in active):
+                finished = True
+        if finished:
             game["status"] = "Finished"
         else:
             # If the checking player was eliminated, figure out the next player; otherwise keep CP

--- a/tests/test_production_agent_routing.py
+++ b/tests/test_production_agent_routing.py
@@ -1,0 +1,163 @@
+"""Unit tests for variant-aware routing in production_agent."""
+
+import os
+import unittest
+
+from nfsp_ai.production_agent import (
+    _model_key_from_filename,
+    _routing_keys,
+    _resolve_model_paths,
+)
+
+
+class FilenameParserTest(unittest.TestCase):
+    def test_legacy_24(self):
+        self.assertEqual(_model_key_from_filename("artifacts/nfsp_inference_24.pt"), "24")
+
+    def test_legacy_32(self):
+        self.assertEqual(_model_key_from_filename("nfsp_inference_32.pt"), "32")
+
+    def test_variant_1v1(self):
+        self.assertEqual(_model_key_from_filename("nfsp_inference_24_1v1.pt"), "24_1v1")
+
+    def test_variant_multi(self):
+        self.assertEqual(
+            _model_key_from_filename("/abs/path/artifacts/nfsp_inference_32_multi.pt"),
+            "32_multi",
+        )
+
+    def test_variant_team(self):
+        self.assertEqual(_model_key_from_filename("nfsp_inference_24_team.pt"), "24_team")
+
+    def test_unknown_filename(self):
+        self.assertIsNone(_model_key_from_filename("something_else.pt"))
+        self.assertIsNone(_model_key_from_filename("nfsp_inference_99.pt"))
+
+
+class RoutingKeysTest(unittest.TestCase):
+    def test_1v1_vanilla_24(self):
+        rules = {"deck_size": 24, "jokers": 0, "blanks": 0, "common_cards": 0}
+        keys = _routing_keys(rules, n_players=2)
+        # Most-specific first; 1v1 then multi then legacy
+        self.assertEqual(keys, ["24_1v1", "24_multi", "24"])
+
+    def test_1v1_vanilla_32(self):
+        rules = {"deck_size": 32, "jokers": 0, "blanks": 0, "common_cards": 0}
+        keys = _routing_keys(rules, n_players=2)
+        self.assertEqual(keys, ["32_1v1", "32_multi", "32"])
+
+    def test_multiplayer_routes_to_multi(self):
+        rules = {"deck_size": 24, "jokers": 0, "blanks": 0, "common_cards": 0}
+        keys = _routing_keys(rules, n_players=4)
+        # n>2 disqualifies 1v1 even with j=b=cc=0
+        self.assertNotIn("24_1v1", keys)
+        self.assertEqual(keys, ["24_multi", "24"])
+
+    def test_jokers_disqualify_1v1(self):
+        rules = {"deck_size": 24, "jokers": 1, "blanks": 0, "common_cards": 0}
+        keys = _routing_keys(rules, n_players=2)
+        self.assertNotIn("24_1v1", keys)
+        self.assertEqual(keys, ["24_multi", "24"])
+
+    def test_blanks_disqualify_1v1(self):
+        rules = {"deck_size": 24, "jokers": 0, "blanks": 2, "common_cards": 0}
+        keys = _routing_keys(rules, n_players=2)
+        self.assertNotIn("24_1v1", keys)
+
+    def test_common_cards_disqualify_1v1(self):
+        rules = {"deck_size": 24, "jokers": 0, "blanks": 0, "common_cards": 1}
+        keys = _routing_keys(rules, n_players=2)
+        self.assertNotIn("24_1v1", keys)
+
+    def test_team_takes_priority(self):
+        rules = {"deck_size": 24, "jokers": 0, "blanks": 0, "common_cards": 0, "teams": True}
+        keys = _routing_keys(rules, n_players=4)
+        self.assertEqual(keys[0], "24_team")
+        # teams disqualify 1v1 even at n=2
+        rules2 = {"deck_size": 24, "jokers": 0, "blanks": 0, "common_cards": 0, "teams": True}
+        keys2 = _routing_keys(rules2, n_players=2)
+        self.assertEqual(keys2[0], "24_team")
+        self.assertNotIn("24_1v1", keys2)
+
+    def test_team_then_multi_then_legacy(self):
+        rules = {"deck_size": 32, "jokers": 1, "teams": True}
+        keys = _routing_keys(rules, n_players=4)
+        self.assertEqual(keys, ["32_team", "32_multi", "32"])
+
+    def test_default_deck_size_when_missing(self):
+        # Deck not specified — defaults to 24
+        keys = _routing_keys({}, n_players=2)
+        self.assertIn("24_multi", keys)
+        self.assertIn("24", keys)
+
+
+class ResolveModelPathsTest(unittest.TestCase):
+    def setUp(self):
+        # Build a temporary artifacts/ in /tmp
+        import tempfile, shutil
+        self.tmp = tempfile.mkdtemp()
+        self.art = os.path.join(self.tmp, "artifacts")
+        os.makedirs(self.art)
+        self.cwd = os.getcwd()
+        os.chdir(self.tmp)
+
+    def tearDown(self):
+        import shutil
+        os.chdir(self.cwd)
+        shutil.rmtree(self.tmp)
+
+    def _touch(self, name):
+        p = os.path.join(self.art, name)
+        with open(p, "wb") as f:
+            f.write(b"")
+        return p
+
+    def test_discovers_legacy_only(self):
+        self._touch("nfsp_inference_24.pt")
+        self._touch("nfsp_inference_32.pt")
+        out = _resolve_model_paths(None)
+        self.assertEqual(set(out.keys()), {"24", "32"})
+
+    def test_discovers_variant_files(self):
+        self._touch("nfsp_inference_24_1v1.pt")
+        self._touch("nfsp_inference_24_multi.pt")
+        self._touch("nfsp_inference_32_multi.pt")
+        out = _resolve_model_paths(None)
+        self.assertEqual(set(out.keys()), {"24_1v1", "24_multi", "32_multi"})
+
+    def test_mixed_legacy_and_variant(self):
+        self._touch("nfsp_inference_24.pt")
+        self._touch("nfsp_inference_24_1v1.pt")
+        self._touch("nfsp_inference_32_multi.pt")
+        out = _resolve_model_paths(None)
+        self.assertEqual(set(out.keys()), {"24", "24_1v1", "32_multi"})
+
+    def test_explicit_path(self):
+        p = self._touch("nfsp_inference_24_multi.pt")
+        out = _resolve_model_paths(p)
+        self.assertEqual(out, {"24_multi": p})
+
+    def test_explicit_path_nonstandard_filename(self):
+        p = os.path.join(self.tmp, "my_custom_model.pt")
+        with open(p, "wb") as f:
+            f.write(b"")
+        out = _resolve_model_paths(p)
+        # Non-standard filename: stored under "explicit", to be rewritten
+        # at load time once act_dim is probed.
+        self.assertEqual(out, {"explicit": p})
+
+    def test_explicit_path_missing(self):
+        out = _resolve_model_paths("/nonexistent/path.pt")
+        self.assertEqual(out, {})
+
+    def test_ignores_random_files(self):
+        self._touch("nfsp_inference_24.pt")
+        self._touch("readme.txt")
+        self._touch("nfsp_blef_5M.pt")
+        out = _resolve_model_paths(None)
+        # Only the proper inference file is picked up
+        self.assertEqual(set(out.keys()), {"24"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_production_agent_routing.py
+++ b/tests/test_production_agent_routing.py
@@ -79,6 +79,25 @@ class RoutingKeysTest(unittest.TestCase):
         self.assertEqual(keys2[0], "24_team")
         self.assertNotIn("24_1v1", keys2)
 
+    def test_team_detected_from_players_list(self):
+        # Engine schema: team field on each player, no rules.teams flag.
+        rules = {"deck_size": 24, "jokers": 0, "blanks": 0, "common_cards": 0}
+        players = [
+            {"nickname": "0", "team": 1},
+            {"nickname": "1", "team": 2},
+            {"nickname": "2", "team": 1},
+            {"nickname": "3", "team": 2},
+        ]
+        keys = _routing_keys(rules, n_players=4, players=players)
+        self.assertEqual(keys[0], "24_team")
+
+    def test_no_team_when_all_player_teams_none(self):
+        rules = {"deck_size": 24, "jokers": 0, "blanks": 0, "common_cards": 0}
+        players = [{"nickname": str(i), "team": None} for i in range(2)]
+        keys = _routing_keys(rules, n_players=2, players=players)
+        self.assertNotIn("24_team", keys)
+        self.assertEqual(keys[0], "24_1v1")
+
     def test_team_then_multi_then_legacy(self):
         rules = {"deck_size": 32, "jokers": 1, "teams": True}
         keys = _routing_keys(rules, n_players=4)

--- a/tests/test_production_agent_routing.py
+++ b/tests/test_production_agent_routing.py
@@ -4,6 +4,7 @@ import os
 import unittest
 
 from nfsp_ai.production_agent import (
+    _canonicalize_to_active,
     _model_key_from_filename,
     _routing_keys,
     _resolve_model_paths,
@@ -37,45 +38,45 @@ class FilenameParserTest(unittest.TestCase):
 class RoutingKeysTest(unittest.TestCase):
     def test_1v1_vanilla_24(self):
         rules = {"deck_size": 24, "jokers": 0, "blanks": 0, "common_cards": 0}
-        keys = _routing_keys(rules, n_players=2)
+        keys = _routing_keys(rules, n_active=2)
         # Most-specific first; 1v1 then multi then legacy
         self.assertEqual(keys, ["24_1v1", "24_multi", "24"])
 
     def test_1v1_vanilla_32(self):
         rules = {"deck_size": 32, "jokers": 0, "blanks": 0, "common_cards": 0}
-        keys = _routing_keys(rules, n_players=2)
+        keys = _routing_keys(rules, n_active=2)
         self.assertEqual(keys, ["32_1v1", "32_multi", "32"])
 
     def test_multiplayer_routes_to_multi(self):
         rules = {"deck_size": 24, "jokers": 0, "blanks": 0, "common_cards": 0}
-        keys = _routing_keys(rules, n_players=4)
+        keys = _routing_keys(rules, n_active=4)
         # n>2 disqualifies 1v1 even with j=b=cc=0
         self.assertNotIn("24_1v1", keys)
         self.assertEqual(keys, ["24_multi", "24"])
 
     def test_jokers_disqualify_1v1(self):
         rules = {"deck_size": 24, "jokers": 1, "blanks": 0, "common_cards": 0}
-        keys = _routing_keys(rules, n_players=2)
+        keys = _routing_keys(rules, n_active=2)
         self.assertNotIn("24_1v1", keys)
         self.assertEqual(keys, ["24_multi", "24"])
 
     def test_blanks_disqualify_1v1(self):
         rules = {"deck_size": 24, "jokers": 0, "blanks": 2, "common_cards": 0}
-        keys = _routing_keys(rules, n_players=2)
+        keys = _routing_keys(rules, n_active=2)
         self.assertNotIn("24_1v1", keys)
 
     def test_common_cards_disqualify_1v1(self):
         rules = {"deck_size": 24, "jokers": 0, "blanks": 0, "common_cards": 1}
-        keys = _routing_keys(rules, n_players=2)
+        keys = _routing_keys(rules, n_active=2)
         self.assertNotIn("24_1v1", keys)
 
     def test_team_takes_priority(self):
         rules = {"deck_size": 24, "jokers": 0, "blanks": 0, "common_cards": 0, "teams": True}
-        keys = _routing_keys(rules, n_players=4)
+        keys = _routing_keys(rules, n_active=4)
         self.assertEqual(keys[0], "24_team")
         # teams disqualify 1v1 even at n=2
         rules2 = {"deck_size": 24, "jokers": 0, "blanks": 0, "common_cards": 0, "teams": True}
-        keys2 = _routing_keys(rules2, n_players=2)
+        keys2 = _routing_keys(rules2, n_active=2)
         self.assertEqual(keys2[0], "24_team")
         self.assertNotIn("24_1v1", keys2)
 
@@ -88,26 +89,92 @@ class RoutingKeysTest(unittest.TestCase):
             {"nickname": "2", "team": 1},
             {"nickname": "3", "team": 2},
         ]
-        keys = _routing_keys(rules, n_players=4, players=players)
+        keys = _routing_keys(rules, n_active=4, players=players)
         self.assertEqual(keys[0], "24_team")
 
     def test_no_team_when_all_player_teams_none(self):
         rules = {"deck_size": 24, "jokers": 0, "blanks": 0, "common_cards": 0}
         players = [{"nickname": str(i), "team": None} for i in range(2)]
-        keys = _routing_keys(rules, n_players=2, players=players)
+        keys = _routing_keys(rules, n_active=2, players=players)
         self.assertNotIn("24_team", keys)
         self.assertEqual(keys[0], "24_1v1")
 
     def test_team_then_multi_then_legacy(self):
         rules = {"deck_size": 32, "jokers": 1, "teams": True}
-        keys = _routing_keys(rules, n_players=4)
+        keys = _routing_keys(rules, n_active=4)
         self.assertEqual(keys, ["32_team", "32_multi", "32"])
 
     def test_default_deck_size_when_missing(self):
         # Deck not specified — defaults to 24
-        keys = _routing_keys({}, n_players=2)
+        keys = _routing_keys({}, n_active=2)
         self.assertIn("24_multi", keys)
         self.assertIn("24", keys)
+
+    def test_4p_collapsed_to_2_active_routes_to_1v1(self):
+        # 4-player vanilla game collapsed to 2 active should route to 1v1.
+        rules = {"deck_size": 24, "jokers": 0, "blanks": 0, "common_cards": 0}
+        players = [
+            {"nickname": "0", "n_cards": 3, "team": None},
+            {"nickname": "1", "n_cards": 0, "team": None},  # eliminated
+            {"nickname": "2", "n_cards": 5, "team": None},
+            {"nickname": "3", "n_cards": 0, "team": None},  # eliminated
+        ]
+        keys = _routing_keys(rules, n_active=2, players=players)
+        self.assertEqual(keys[0], "24_1v1")
+
+    def test_4p_with_3_active_does_not_route_to_1v1(self):
+        # 3 active players — neither 1v1 nor multi-eliminated; goes to multi.
+        rules = {"deck_size": 24, "jokers": 0, "blanks": 0, "common_cards": 0}
+        keys = _routing_keys(rules, n_active=3)
+        self.assertNotIn("24_1v1", keys)
+        self.assertEqual(keys[0], "24_multi")
+
+    def test_collapsed_with_jokers_does_not_route_to_1v1(self):
+        # Even at n_active=2, jokers disqualify 1v1.
+        rules = {"deck_size": 32, "jokers": 1, "blanks": 0, "common_cards": 0}
+        keys = _routing_keys(rules, n_active=2)
+        self.assertNotIn("32_1v1", keys)
+
+
+class CanonicalizeToActiveTest(unittest.TestCase):
+    def test_drops_eliminated_players(self):
+        gs = {
+            "cp_nickname": "alice",
+            "rules": {"deck_size": 24},
+            "players": [
+                {"nickname": "alice", "n_cards": 3},
+                {"nickname": "bob", "n_cards": 0},
+                {"nickname": "carol", "n_cards": 5},
+                {"nickname": "dave", "n_cards": 0},
+            ],
+            "history": [],
+        }
+        out = _canonicalize_to_active(gs)
+        self.assertEqual([p["nickname"] for p in out["players"]], ["alice", "carol"])
+
+    def test_preserves_input_when_no_eliminations(self):
+        gs = {
+            "cp_nickname": "alice",
+            "rules": {"deck_size": 24},
+            "players": [
+                {"nickname": "alice", "n_cards": 3},
+                {"nickname": "bob", "n_cards": 5},
+            ],
+        }
+        out = _canonicalize_to_active(gs)
+        self.assertIs(out, gs)  # short-circuit returns the same dict
+
+    def test_does_not_mutate_input(self):
+        gs = {
+            "cp_nickname": "alice",
+            "players": [
+                {"nickname": "alice", "n_cards": 3},
+                {"nickname": "bob", "n_cards": 0},
+            ],
+        }
+        original_players = list(gs["players"])
+        _ = _canonicalize_to_active(gs)
+        self.assertEqual(gs["players"], original_players)
 
 
 class ResolveModelPathsTest(unittest.TestCase):

--- a/tools/team_curve_logger.py
+++ b/tools/team_curve_logger.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Poll a training run's latest checkpoint and run a team-aware eval each
+time it changes. Emit one line per eval — feeds the Monitor.
+
+Usage:
+  team_curve_logger.py LABEL RUN_DIR DECK_SIZE [GAMES] [SEEDS]
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+# Make repo importable
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.abspath(os.path.join(_HERE, ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from tools.team_eval import run_team_eval
+
+
+def _ckpt_step_from_metrics(run_dir: str) -> int:
+    p = os.path.join(run_dir, "metrics.csv")
+    if not os.path.exists(p):
+        return 0
+    try:
+        with open(p) as f:
+            last = ""
+            for line in f:
+                if line.strip():
+                    last = line
+        return int(float(last.split(",")[0]))
+    except Exception:
+        return 0
+
+
+def main():
+    if len(sys.argv) < 4:
+        print("usage: team_curve_logger.py LABEL RUN_DIR DECK [GAMES] [SEEDS] [PID]", file=sys.stderr)
+        sys.exit(2)
+    label = sys.argv[1]
+    run = sys.argv[2]
+    deck = int(sys.argv[3])
+    games = int(sys.argv[4]) if len(sys.argv) > 4 else 200
+    seeds = int(sys.argv[5]) if len(sys.argv) > 5 else 2
+    pid = int(sys.argv[6]) if len(sys.argv) > 6 else 0
+    poll = 120  # seconds; checkpoint saves usually less frequent than this
+
+    ckpt = os.path.join(run, "checkpoints", "nfsp_blef.pt")
+    card = f"/Users/adriangolian/work/blef_ai/artifacts/card_embedding_pretrain_{deck}.pt"
+    hist = f"/Users/adriangolian/work/blef_ai/artifacts/history_embedding_pretrain_{deck}.pt"
+
+    print(f"[{label}] team-curve armed; ckpt={ckpt} games={games} seeds={seeds} poll={poll}s")
+    sys.stdout.flush()
+
+    last_mtime = 0.0
+    last_eval_step = -1
+
+    def _alive() -> bool:
+        if pid <= 0:
+            return True  # no pid given => skip liveness check
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
+
+    while True:
+        if not _alive():
+            print(f"[{label}] CRASH: pid {pid} exited.")
+            sys.stdout.flush()
+            return
+        if not os.path.exists(ckpt):
+            time.sleep(poll)
+            continue
+        try:
+            mtime = os.path.getmtime(ckpt)
+        except OSError:
+            time.sleep(poll)
+            continue
+        if mtime <= last_mtime:
+            time.sleep(poll)
+            continue
+        last_mtime = mtime
+
+        step = _ckpt_step_from_metrics(run)
+        if step <= last_eval_step:
+            time.sleep(poll)
+            continue
+        last_eval_step = step
+
+        # Average over `seeds` runs
+        twrs = []
+        trws = []
+        iwrs = []
+        try:
+            for seed in range(seeds):
+                r = run_team_eval(
+                    ckpt,
+                    deck_size=deck,
+                    n_players=4,
+                    n_teams=2,
+                    max_cards=11,
+                    games=games,
+                    seed=seed,
+                    card_embedding_path=card,
+                    history_embedding_path=hist,
+                )
+                twrs.append(r["team_winrate"])
+                trws.append(r["team_avg_reward"])
+                iwrs.append(r["indiv_winrate"])
+        except Exception as e:
+            print(f"[{label}] eval failed at step={step}: {e!r}")
+            sys.stdout.flush()
+            time.sleep(poll)
+            continue
+        twr = sum(twrs) / len(twrs)
+        trw = sum(trws) / len(trws)
+        iwr = sum(iwrs) / len(iwrs)
+        std = (sum((x - twr) ** 2 for x in twrs) / len(twrs)) ** 0.5
+        stderr = std / (len(twrs) ** 0.5)
+        print(
+            f"[{label}] team-eval step={step:>9d} "
+            f"team_wr={twr:.4f}±{stderr:.4f} "
+            f"team_rew={trw:+.4f} "
+            f"indiv_wr={iwr:.4f}"
+        )
+        sys.stdout.flush()
+        time.sleep(poll)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/team_eval.py
+++ b/tools/team_eval.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Team-aware evaluation of an NFSP learner against ConservativeAgent in
+team-mode games.
+
+The in-training eval (`_evaluate_policy` in `nfsp_ai/agent.py`) and
+`tools/eval_ladder` both score from the *individual* learner perspective
+("did the loss-card land on me?"). For a team specialist, the right
+metric is whether the loser is on the LEARNER's team or the opponent
+team. This script does that.
+
+Reports per-config:
+  - team_winrate:  (rounds where loser was on opp team) / (settled rounds)
+  - team_avg_reward: mean of [+1 if opp-team loser, -1 if our-team loser]
+  - indiv_winrate: same as the in-training metric, for cross-check
+  - n_settled_rounds, n_games
+
+Usage:
+  python -m tools.team_eval \
+      --checkpoint runs/.../checkpoints/nfsp_blef.pt \
+      --deck-size 24 \
+      --n-players 4 --n-teams 2 --max-cards 11 \
+      --games 400 --seeds 5
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import sys
+import time
+from typing import Optional
+
+import numpy as np
+import torch
+
+# Make the project tree importable regardless of how the script is run.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.abspath(os.path.join(_HERE, ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from conservative_ai.agent import ConservativeAgent  # type: ignore
+from nfsp_ai.agent import NFSPAgent, NFSPConfig  # type: ignore
+from nfsp_ai.nfsp_run_local import (  # type: ignore
+    MyEnv,
+    _build_deck_spec,
+    _load_card_embedding,
+    _load_history_embedding,
+)
+
+
+def _legal_or_random(action: Optional[int], mask: torch.Tensor) -> int:
+    if action is not None and 0 <= int(action) < int(mask.numel()) and mask[int(action)] > 0:
+        return int(action)
+    legal = mask.nonzero(as_tuple=False).view(-1).tolist()
+    return int(random.choice(legal)) if legal else 0
+
+
+def _infer_dims_from_q_state(q_sd: dict) -> tuple[int, int, bool]:
+    """Return (obs_dim, act_dim, factorize) by probing the Q-net state dict.
+
+    Plain net: net.0.weight = [hidden, obs_dim], net.4.weight = [act_dim, hidden]
+    Factorized: trunk.0.weight = [hidden, obs_dim], bet_head.weight = [act_dim-1, hidden],
+                check_head.weight = [1, hidden]; act_dim = bet+1.
+    """
+    if "trunk.0.weight" in q_sd:
+        obs_dim = int(q_sd["trunk.0.weight"].shape[1])
+        bet = int(q_sd["bet_head.weight"].shape[0])
+        act_dim = bet + 1
+        return obs_dim, act_dim, True
+    if "net.0.weight" in q_sd:
+        obs_dim = int(q_sd["net.0.weight"].shape[1])
+        # Find the last linear layer in net.* — its first dim is act_dim.
+        last_idx = max(
+            int(k.split(".")[1]) for k in q_sd
+            if k.startswith("net.") and k.endswith(".weight")
+        )
+        act_dim = int(q_sd[f"net.{last_idx}.weight"].shape[0])
+        return obs_dim, act_dim, False
+    raise ValueError("could not infer obs_dim/act_dim from Q-net state dict")
+
+
+def _build_learner_from_checkpoint(path: str, device: str = "cpu") -> NFSPAgent:
+    """Load either an inference export OR a training-time checkpoint."""
+    ckpt = torch.load(path, map_location=device, weights_only=False)
+    cfg_d = ckpt.get("cfg", {}) or {}
+    base = NFSPConfig()
+    q_sd = ckpt["q"]
+
+    if "obs_dim" in ckpt and "act_dim" in ckpt:
+        obs_dim = int(ckpt["obs_dim"])
+        act_dim = int(ckpt["act_dim"])
+        factorize_probe = "trunk.0.weight" in q_sd
+    else:
+        # Training checkpoint — infer from state dict.
+        obs_dim, act_dim, factorize_probe = _infer_dims_from_q_state(q_sd)
+
+    hidden = cfg_d.get("hidden")
+    if hidden is None:
+        for k in ("net.0.weight", "trunk.0.weight"):
+            if k in q_sd:
+                hidden = int(q_sd[k].shape[0])
+                break
+        if hidden is None:
+            hidden = base.hidden
+
+    factorize = cfg_d.get("factorize_action_head")
+    if factorize is None:
+        factorize = factorize_probe
+
+    cfg = NFSPConfig(**{**base.__dict__, **{
+        "hidden": int(hidden),
+        "factorize_action_head": bool(factorize),
+        "anticipatory_eta": cfg_d.get("anticipatory_eta", base.anticipatory_eta),
+    }})
+    cfg.rl_capacity = 1
+    cfg.sl_capacity = 1
+    cfg.batch_rl = 1
+    cfg.batch_sl = 1
+    cfg.train_rl_every = 1
+    cfg.train_sl_every = 1
+    cfg.warmup_steps = 0
+
+    learner = NFSPAgent(
+        obs_dim=obs_dim,
+        act_dim=act_dim,
+        device=torch.device(device),
+        cfg=cfg,
+    )
+    learner.q.load_state_dict(ckpt["q"])
+    learner.pi.load_state_dict(ckpt["pi"])
+    learner.q.eval()
+    learner.pi.eval()
+    learner.rl_buf = None
+    learner.sl_buf = None
+    return learner
+
+
+def _team_of(players: list, nick: str) -> Optional[int]:
+    for p in players:
+        if p.get("nickname") == nick:
+            t = p.get("team")
+            return None if t is None else int(t)
+    return None
+
+
+def run_team_eval(
+    checkpoint: str,
+    *,
+    deck_size: int,
+    n_players: int,
+    n_teams: int,
+    max_cards: int,
+    jokers: int = 0,
+    blanks: int = 0,
+    common_cards: int = 0,
+    games: int = 400,
+    seed: int = 0,
+    card_embedding_path: Optional[str] = None,
+    history_embedding_path: Optional[str] = None,
+    device: str = "cpu",
+) -> dict:
+    random.seed(seed)
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+
+    learner = _build_learner_from_checkpoint(checkpoint, device=device)
+
+    card_emb = _load_card_embedding(card_embedding_path, device=device) if card_embedding_path else None
+    hist_emb = _load_history_embedding(history_embedding_path, device=device) if history_embedding_path else None
+
+    env = MyEnv(
+        n_agents=n_players,
+        max_cards=max_cards,
+        deck_size=deck_size,
+        jokers=jokers,
+        blanks=blanks,
+        common_cards=common_cards,
+        n_teams=n_teams,
+        card_embedding=card_emb,
+        history_embedding=hist_emb,
+    )
+
+    # Sanity: obs_dim match
+    obs, _mask, _pid = env.reset()
+    if int(obs.shape[-1]) != int(learner.obs_dim):
+        raise ValueError(
+            f"env obs_dim {int(obs.shape[-1])} != learner obs_dim {int(learner.obs_dim)} "
+            f"(deck/jokers/blanks/common_cards / embeddings mismatch)"
+        )
+
+    env = MyEnv(
+        n_agents=n_players,
+        max_cards=max_cards,
+        deck_size=deck_size,
+        jokers=jokers,
+        blanks=blanks,
+        common_cards=common_cards,
+        n_teams=n_teams,
+        card_embedding=card_emb,
+        history_embedding=hist_emb,
+    )
+
+    team_wins = team_losses = 0
+    indiv_wins = indiv_losses = 0
+    total_rounds = 0
+    t0 = time.time()
+
+    for _g in range(games):
+        obs, mask, _pid = env.reset()
+        ref = env._ref_nick
+        ref_team = _team_of(env.game.get("players") or [], ref)
+        done = False
+        while not done:
+            cp = env.game.get("cp_nickname")
+            if cp == ref:
+                a = learner.select_action(obs, mask, use_average_policy=True, greedy=True)
+                a = _legal_or_random(a, mask)
+            else:
+                a = ConservativeAgent.determine_action(env.game)
+                a = _legal_or_random(a, mask)
+            obs, mask, _r, done, info = env.step(int(a))
+            rr = (info or {}).get("round_result") or {}
+            loser = rr.get("loser")
+            if loser:
+                total_rounds += 1
+                # Individual perspective (matches in-training eval)
+                if loser == ref:
+                    indiv_losses += 1
+                else:
+                    indiv_wins += 1
+                # Team perspective
+                loser_team = _team_of(env.game.get("players") or [], loser)
+                if ref_team is not None and loser_team is not None:
+                    if loser_team == ref_team:
+                        team_losses += 1
+                    else:
+                        team_wins += 1
+
+    dur = time.time() - t0
+    settled = team_wins + team_losses
+    indiv_settled = indiv_wins + indiv_losses
+    return {
+        "checkpoint": checkpoint,
+        "deck_size": deck_size,
+        "n_players": n_players,
+        "n_teams": n_teams,
+        "max_cards": max_cards,
+        "jokers": jokers,
+        "blanks": blanks,
+        "common_cards": common_cards,
+        "games": games,
+        "seed": seed,
+        "n_rounds": total_rounds,
+        "team_winrate": (team_wins / settled) if settled else float("nan"),
+        "team_avg_reward": ((team_wins - team_losses) / settled) if settled else float("nan"),
+        "indiv_winrate": (indiv_wins / indiv_settled) if indiv_settled else float("nan"),
+        "team_settled_rounds": settled,
+        "indiv_settled_rounds": indiv_settled,
+        "duration_sec": round(dur, 2),
+    }
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--checkpoint", required=True)
+    p.add_argument("--deck-size", type=int, required=True)
+    p.add_argument("--n-players", type=int, default=4)
+    p.add_argument("--n-teams", type=int, default=2)
+    p.add_argument("--max-cards", type=int, default=11)
+    p.add_argument("--jokers", type=int, default=0)
+    p.add_argument("--blanks", type=int, default=0)
+    p.add_argument("--common-cards", type=int, default=0)
+    p.add_argument("--games", type=int, default=400)
+    p.add_argument("--seeds", type=int, default=5, help="number of seeds to average over")
+    p.add_argument("--card-embedding", default=None)
+    p.add_argument("--history-embedding", default=None)
+    p.add_argument("--device", default="cpu")
+    p.add_argument("--out", default=None, help="optional JSON output path")
+    args = p.parse_args(argv)
+
+    rows = []
+    for seed in range(args.seeds):
+        r = run_team_eval(
+            args.checkpoint,
+            deck_size=args.deck_size,
+            n_players=args.n_players,
+            n_teams=args.n_teams,
+            max_cards=args.max_cards,
+            jokers=args.jokers,
+            blanks=args.blanks,
+            common_cards=args.common_cards,
+            games=args.games,
+            seed=seed,
+            card_embedding_path=args.card_embedding,
+            history_embedding_path=args.history_embedding,
+            device=args.device,
+        )
+        rows.append(r)
+        print(
+            f"[seed={seed}] team_wr={r['team_winrate']:.4f} "
+            f"team_rew={r['team_avg_reward']:+.4f} "
+            f"indiv_wr={r['indiv_winrate']:.4f} "
+            f"rounds={r['n_rounds']} dur={r['duration_sec']}s"
+        )
+
+    if rows:
+        twrs = [r["team_winrate"] for r in rows if r["team_winrate"] == r["team_winrate"]]
+        trew = [r["team_avg_reward"] for r in rows if r["team_avg_reward"] == r["team_avg_reward"]]
+        iwrs = [r["indiv_winrate"] for r in rows if r["indiv_winrate"] == r["indiv_winrate"]]
+        if twrs:
+            mean = sum(twrs) / len(twrs)
+            std = (sum((x - mean) ** 2 for x in twrs) / len(twrs)) ** 0.5
+            stderr = std / (len(twrs) ** 0.5)
+            print(
+                f"[summary] team_wr={mean:.4f} ± {stderr:.4f} "
+                f"team_rew={sum(trew)/len(trew):+.4f} "
+                f"indiv_wr={sum(iwrs)/len(iwrs):.4f}  ({len(twrs)} seeds)"
+            )
+
+    if args.out:
+        with open(args.out, "w") as f:
+            json.dump(rows, f, indent=2)
+        print(f"wrote {args.out}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/team_eval_curve.sh
+++ b/tools/team_eval_curve.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Build a team-aware eval CURVE by running tools.team_eval against every
+# named-step checkpoint plus the latest .pt for one or more run dirs.
+#
+# Usage:
+#   tools/team_eval_curve.sh DECK 24|32 RUN_DIR [RUN_DIR2 ...]
+#
+# Output: one line per (run, step) point — easy to eyeball as a text curve.
+set -euo pipefail
+
+DECK="${1:?deck size required}"
+shift
+RUNS=("$@")
+PY="${PY:-/Users/adriangolian/work/blef_ai/venv_nfsp/bin/python}"
+ROOT="${ROOT:-/tmp/blef_train2}"
+
+CARD="/Users/adriangolian/work/blef_ai/artifacts/card_embedding_pretrain_${DECK}.pt"
+HIST="/Users/adriangolian/work/blef_ai/artifacts/history_embedding_pretrain_${DECK}.pt"
+
+GAMES=400
+SEEDS=3
+
+cd "$ROOT"
+echo "step_label    team_wr team_rew indiv_wr  ckpt"
+for run in "${RUNS[@]}"; do
+  base=$(basename "$run")
+  ckdir="$run/checkpoints"
+  if [ ! -d "$ckdir" ]; then continue; fi
+  for ck in $(ls "$ckdir"/nfsp_blef_*M.pt 2>/dev/null | sort -V) "$ckdir"/nfsp_blef.pt; do
+    [ -f "$ck" ] || continue
+    label=$(basename "$ck" | sed -e 's/nfsp_blef_//' -e 's/\.pt//' -e 's/^nfsp_blef$/latest/')
+    out=$($PY -m tools.team_eval \
+      --checkpoint "$ck" --deck-size "$DECK" \
+      --n-players 4 --n-teams 2 --max-cards 11 \
+      --games "$GAMES" --seeds "$SEEDS" \
+      --card-embedding "$CARD" \
+      --history-embedding "$HIST" 2>&1 | grep summary || true)
+    twr=$(echo "$out" | sed -nE 's/.*team_wr=([0-9.+-]+).*/\1/p')
+    trw=$(echo "$out" | sed -nE 's/.*team_rew=([0-9.+-]+).*/\1/p')
+    iwr=$(echo "$out" | sed -nE 's/.*indiv_wr=([0-9.+-]+).*/\1/p')
+    printf "%-13s %-7s %-8s %-9s %s\n" "$base@$label" "$twr" "$trw" "$iwr" "$ck"
+  done
+done

--- a/tools/training_watcher.py
+++ b/tools/training_watcher.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Watch NFSP training metrics for plateau / regression / divergence.
+
+Reads metrics.csv every poll, computes rolling slopes, and prints one
+line per scheduled snapshot or anomaly. Exit when training PID dies.
+
+Schema (current): step, avg_reward, win_rate, avg_len, q_loss, sl_loss,
+policy_entropy, illegal_rate, epsilon, anticipatory_eta, lr_q, n_step,
+train_rl_every, check_explore_prob, max_cards, rl_buf, sl_buf, ...
+
+Each step appears twice in the file (BR row + behavior row); we use the
+BR rows (those with non-empty q_loss / sl_loss).
+"""
+from __future__ import annotations
+
+import csv
+import os
+import signal
+import sys
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Optional, Tuple
+
+
+def _read_br_rows(path: str) -> list[dict]:
+    rows: list[dict] = []
+    if not os.path.exists(path):
+        return rows
+    with open(path) as f:
+        rd = csv.DictReader(f)
+        for r in rd:
+            # BR rows have q_loss / sl_loss populated (not empty / nan)
+            qv = r.get("q_loss", "")
+            if qv == "" or qv == "nan":
+                continue
+            try:
+                rows.append({
+                    "step": int(r["step"]),
+                    "avg_reward": float(r["avg_reward"]),
+                    "win_rate": float(r["win_rate"]),
+                    "q_loss": float(r["q_loss"]),
+                    "sl_loss": float(r["sl_loss"]),
+                    "policy_entropy": float(r.get("policy_entropy", "nan") or "nan"),
+                    "epsilon": float(r.get("epsilon", "nan") or "nan"),
+                    "eta": float(r.get("anticipatory_eta", "nan") or "nan"),
+                    "rl_buf": int(float(r.get("rl_buf", 0) or 0)),
+                    "sl_buf": int(float(r.get("sl_buf", 0) or 0)),
+                })
+            except (ValueError, KeyError):
+                continue
+    return rows
+
+
+@dataclass
+class Slope:
+    delta: float
+    span_steps: int
+
+    @property
+    def per_M(self) -> float:
+        return self.delta / max(1, self.span_steps) * 1_000_000
+
+
+def _slope_over_steps(rows: list[dict], field: str, window_steps: int) -> Optional[Slope]:
+    if len(rows) < 2:
+        return None
+    last = rows[-1]
+    target_step = last["step"] - window_steps
+    # Find the row with step closest to (and >=) target_step
+    pivot = None
+    for r in rows:
+        if r["step"] >= target_step:
+            pivot = r
+            break
+    if pivot is None or pivot is last:
+        return None
+    return Slope(delta=last[field] - pivot[field], span_steps=last["step"] - pivot["step"])
+
+
+def main():
+    if len(sys.argv) < 4:
+        print("usage: training_watcher.py <label> <run_dir> <pid> [poll_sec]", file=sys.stderr)
+        sys.exit(2)
+    label = sys.argv[1]
+    run_dir = sys.argv[2]
+    pid = int(sys.argv[3])
+    poll = int(sys.argv[4]) if len(sys.argv) >= 5 else 60
+    csv_path = os.path.join(run_dir, "metrics.csv")
+    last_step_seen = -1
+    last_snapshot_step = -1
+    snapshot_every = 200_000  # one snapshot line per 200K steps
+    anomaly_seen = set()  # avoid spamming the same anomaly
+
+    def alive() -> bool:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
+
+    print(f"[{label}] watcher armed; pid={pid} poll={poll}s")
+    sys.stdout.flush()
+
+    while True:
+        if not alive():
+            rows = _read_br_rows(csv_path)
+            last = rows[-1] if rows else None
+            print(f"[{label}] CRASH: pid {pid} exited. last step={last['step'] if last else 'n/a'}")
+            sys.stdout.flush()
+            return
+
+        rows = _read_br_rows(csv_path)
+        if not rows:
+            time.sleep(poll)
+            continue
+        last = rows[-1]
+        if last["step"] == last_step_seen:
+            time.sleep(poll)
+            continue
+        last_step_seen = last["step"]
+
+        # Snapshot line every snapshot_every steps
+        if last["step"] - last_snapshot_step >= snapshot_every:
+            wr_slope_1M = _slope_over_steps(rows, "win_rate", 1_000_000)
+            rew_slope_1M = _slope_over_steps(rows, "avg_reward", 1_000_000)
+            slope_str = ""
+            if wr_slope_1M:
+                slope_str = (
+                    f" wrΔ/1M={wr_slope_1M.per_M:+.3f}"
+                    f" rewΔ/1M={rew_slope_1M.per_M:+.3f}"
+                    if rew_slope_1M else ""
+                )
+            print(
+                f"[{label}] step={last['step']:>9d} "
+                f"rew={last['avg_reward']:.3f} wr={last['win_rate']:.3f} "
+                f"q={last['q_loss']:.3f} sl={last['sl_loss']:.3f} "
+                f"H={last['policy_entropy']:.2f} "
+                f"η={last['eta']:.2f} ε={last['epsilon']:.2f}"
+                f"{slope_str}"
+            )
+            sys.stdout.flush()
+            last_snapshot_step = last["step"]
+
+        # === Anomaly checks (each fires once per training) ===
+        # Only run after we have at least 1M steps of data
+        if last["step"] < 1_000_000:
+            time.sleep(poll)
+            continue
+
+        # 1) win-rate plateau over last 2M steps — slope < 0.005 per 1M
+        if "wr_plateau_2M" not in anomaly_seen:
+            s = _slope_over_steps(rows, "win_rate", 2_000_000)
+            if s and s.span_steps >= 1_500_000 and abs(s.per_M) < 0.005:
+                print(
+                    f"[{label}] ANOMALY win_rate plateau: Δ/1M={s.per_M:+.4f} "
+                    f"over {s.span_steps:,} steps (last wr={last['win_rate']:.3f}). "
+                    "consider eta↑ or epsilon adjust."
+                )
+                sys.stdout.flush()
+                anomaly_seen.add("wr_plateau_2M")
+
+        # 2) avg_reward regression — sustained drop > 0.05 over 1.5M steps.
+        #    eval stderr is ~0.035 per sample (50K-step eval = ~50-100 games),
+        #    so 500K windows trip on noise. 1.5M window is ~30 samples,
+        #    which dampens single-sample swings.
+        if "rew_regression" not in anomaly_seen:
+            s = _slope_over_steps(rows, "avg_reward", 1_500_000)
+            if s and s.span_steps >= 1_200_000 and s.delta < -0.05:
+                print(
+                    f"[{label}] ANOMALY avg_reward regression: Δ={s.delta:+.3f} "
+                    f"over {s.span_steps:,} steps (now {last['avg_reward']:.3f}). "
+                    "investigate."
+                )
+                sys.stdout.flush()
+                anomaly_seen.add("rew_regression")
+
+        # 3) sl_loss explosion — abs > 3.0 sustained or rise > 0.5 over 500K
+        if "sl_explosion" not in anomaly_seen:
+            if last["sl_loss"] > 3.0:
+                print(
+                    f"[{label}] ANOMALY sl_loss > 3.0 (={last['sl_loss']:.3f}). "
+                    "SL divergence; consider sl_learning_off pulse or lr_pi cut."
+                )
+                sys.stdout.flush()
+                anomaly_seen.add("sl_explosion")
+            else:
+                s = _slope_over_steps(rows, "sl_loss", 500_000)
+                if s and s.span_steps >= 400_000 and s.delta > 0.5:
+                    print(
+                        f"[{label}] ANOMALY sl_loss climb: Δ={s.delta:+.3f} "
+                        f"over {s.span_steps:,} steps (now {last['sl_loss']:.3f})."
+                    )
+                    sys.stdout.flush()
+                    anomaly_seen.add("sl_explosion")
+
+        # 4) q_loss reversal — was decreasing, now climbing > 0.05 over 500K
+        if "q_reversal" not in anomaly_seen:
+            s = _slope_over_steps(rows, "q_loss", 500_000)
+            if s and s.span_steps >= 400_000 and s.delta > 0.05:
+                # Check that q_loss had been decreasing previously
+                s_prev = _slope_over_steps(rows[:-1], "q_loss", 1_000_000)
+                if s_prev and s_prev.delta < -0.05:
+                    print(
+                        f"[{label}] ANOMALY q_loss reversal: "
+                        f"recent Δ={s.delta:+.3f}, prior trend was {s_prev.delta:+.3f}."
+                    )
+                    sys.stdout.flush()
+                    anomaly_seen.add("q_reversal")
+
+        time.sleep(poll)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR has grown beyond pure variant-aware routing — it now bundles all the changes needed to ship per-variant specialists (24-deck × 1v1/multi/team and 32-deck × 1v1/multi/team), including the team-mode training infrastructure that was previously tracked in #64. #64 is superseded.

### Routing layer (original scope)
- `production_agent.py`: glob-discovery of `artifacts/nfsp_inference_<deck>[_<variant>].pt`; routing chain by `(deck, n_active, jokers, blanks, common_cards, teams)` with most-specific key first and a legacy `<deck>` fallback.
- Team mode detected from `players[*].team` (engine PR #220 schema) — no extra rules flag required.
- Routes by **active** player count, not seated. A 4p game collapsed to 2 active routes to `<deck>_1v1` and the obs is canonicalized (eliminated seats stripped) so the 1v1 specialist sees in-distribution input.
- Loader honors `factorize_action_head` from cfg, with state-dict shape probe fallback for older exports — fixes silent `load_state_dict` failure on the 32_1v1 (deck32-8M) factorized specialist.

### Team-mode training (was #64)
- `simpleschema_local_manager`: `_assign_teams` partition + shuffle; `create_game(n_teams=…)` propagates `team` field per player; `handle_check` end-condition handles team-elimination.
- `MyEnv` gains `n_teams`, `pick_n_teams_in_range` flags + per-game team sampler.
- Team-aware terminal reward: `-1` if loser is on actor's team, `+1` otherwise.
- `MAX_ROUNDS` raised 50 → 200 (team games run longer).

### Team-aware obs encoding + action masking + credit (this PR's late additions)
The first round of team training discovered the model had **zero** information about team identity in its input and was being trained with **anti-team** n-step credit propagation. This PR fixes all three:
- `vectorize_obs` now appends a per-slot team flag (`+1` teammate / `-1` opponent / `0` none), rotated through the same slot mapping as seat counts. obs_dim grows by `MAX_PLAYERS` (8) for both decks.
- `_legal_action_mask` enforces:
  - **Rule 1**: forbid CHECK if last bettor is on actor's team.
  - **Rule 2**: forbid the top-of-ladder bet (`check_id - 1`) if next-in-turn is on actor's team and there are ≥2 legal raises (one-step lookahead = "force teammate to check **my own** bet"). Falls back to allowing CHECK if both rules together would zero the mask.
- `_flush_nstep`: per-step credit sign uses `actor_team == loser_team` when team info is set; falls back to `actor_id == loser_id` for solo-mode trajectories.
- In-training win/reward metric is now team-aware so the ref's TEAM (not individual) score is reported during training.

### Tests
- `tests/test_production_agent_routing.py` — 30 tests covering filename parsing, routing keys, glob discovery, team detection from players, n_active routing, canonicalization (no-mutation, drop-eliminated, short-circuit on no-eliminations).
- 76/77 in the broader suite pass; the 1 failure is a pre-existing `games/` dir issue in `test_simpleschema_manager`, unrelated.

## Test plan
- [x] Routing tests: 30/30 pass
- [x] Loader smoke test: all 6 inference artifacts (`24`, `24_1v1`, `24_multi`, `32`, `32_1v1`, `32_multi`) load via `NFSPProductionAgent`
- [x] End-to-end inference: `determine_action` returns valid actions for 24/32 × 1v1/multi/4p-collapsed-to-2-active
- [x] Team-mode env smoke: `MyEnv` with `n_teams=2` produces correct team field per player; reward flips sign when loser is teammate vs opponent
- [x] Team obs encoding smoke: obs_dim 326→334 for 24-deck; team flags rotate consistently with seat counts
- [x] Team mask smoke: `n=4` 2-team game with last bettor on actor's team correctly forbids CHECK; with next-in-turn teammate forbids `check_id-1`
- [ ] Multi-seed team eval against Conservative (deferred — team trainings still in flight)
- [ ] Lambda image rebuild + smoke test on a 1v1 / 4p / team game (deferred to deploy step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)