### PR TITLE
Bot personalities: 16 Slavic-pantheon play-styles on one shared NFSP image

### DIFF
--- a/docs/bot_personalities_plan.md
+++ b/docs/bot_personalities_plan.md
@@ -1,0 +1,200 @@
+# Bot Personalities Plan — Slavic-pantheon play-style bots
+
+## Validation results (160 games/god vs the standard NFSP baseline, deck 24)
+
+Measured with `tools/personality_winrate.py` (full games via the training manager
+`simpleschema_local_manager`) and `tools/personality_probe.py` (move signatures).
+Calibration: baseline-vs-baseline 46.9% (≈50%, slight seat bias). Heuristic floor:
+`conservative_ai` 20.0%, `conservative_crawling` 22.5%.
+
+| tier | gods (win% vs baseline) |
+|---|---|
+| wall / strong (≈baseline) | perun 51, svetovid 52, dazhbog 52, mokosh 50, triglav 49, porevit 48, zorya 46, kupala 44 |
+| mid | mavka 32, rusalka 30 |
+| loud / easy | czernobog 28, veles 28, poludnica 26, leshy 24, domovoi 22 (crawling), baba_yaga 22 |
+
+Every god lands in 20–52% — weaker-but-competitive, none a free win, none constantly
+losing (tempo/chaos bounded). Move signatures confirm intent: disciplined gods (mokosh,
+svetovid, veles) low-bluff + concealed; loud gods (czernobog, baba_yaga, leshy) bluffy +
+chaotic but coherent; mood cohorts fire correctly (poludnica spikes late −0.27 pPriv; perun
+bolder when ahead; zorya swings by round parity). Chaos is in-distribution top-k sampling,
+not temperature (temperature collapsed the peaked NFSP policy toward random).
+
+## Context
+
+We have strong, near-equilibrium Blef AIs: 6 NFSP specialists (deck 24/32 × 1v1/multi/team,
+served by one ECR container `blef-aiagent-nfsp` with internal variant routing) and a separate
+CFR bot (`blef-aiagent-cfr` → 66 hand-size workers, 1v1/24 only). We have art + animations for
+~17 named deities and want each to feel like a distinct *character*: different difficulty AND
+recognizable quirks ("don't trust Morana when she goes quiet"; "Perun always overcommits late").
+
+The constraint is cost: we must not upload N Docker images to ECR. The decision (made with the
+user) is **Path B** — keep **one** NFSP image and **one** function `blef-aiagent-nfsp`; the
+personality is selected per move by a field in the payload. On-demand only (no provisioned
+concurrency), so a shared warm pool that loads the model once is the efficient choice.
+
+Two anchors are fixed:
+- **Morana** = the CFR bot (Nash-like, minimal-tell, patient) — *already a perfect Ice Queen*. No
+  work; she stays on `blef-aiagent-cfr` and can only be seated in 1v1/24 games.
+- **Perun** = the strong NFSP baseline (the difficulty wall), with a light Warlord tint.
+
+Everything else is **inference-time sculpting** over the *shared* NFSP weights — no retraining.
+A personality is a small config (a knob vector + optional mood rule), not a new artifact.
+
+## Design: two orthogonal axes
+
+- **Difficulty** (how strong) — emerges from how far a bot is pushed off equilibrium plus chaos.
+  Biasing a near-Nash policy *is* deviating from it, so quirkier ⇒ more exploitable ⇒ easier. The
+  two unbiased bots (Perun=NFSP baseline, Morana=CFR) are the hardest *by construction*.
+- **Personality** (how flavored) — primarily the *choice of NFSP policy* (below), then a bounded
+  output overlay + a stateless "mood" that shifts the knobs over a game.
+
+### Policy source (NFSP-native — the PRIMARY style axis)
+
+The probability overlay in the next section, used alone, is just a parametrised heuristic
+(essentially the existing `conservative_ai`): crank it and the NFSP signal washes out. To get
+genuinely *NFSP-based* playstyles the model itself is the primary axis; the overlay is a bounded
+perturbation on top. NFSP-native levers (no retraining — both heads already live in every inference
+artifact: `export_inference` saves `q` and `pi`, and `select_action(use_average_policy=False)` runs `q`):
+
+- **Head** — `π` (average policy: balanced Nash approximation, prod default) vs `Q` (best-response:
+  sharper, greedier, more exploitative *and* more exploitable). A real, free style switch.
+- **Model temperature** `τ_model` — softmax temperature on the chosen head's *own* logits. Low ⇒
+  decisive; high ⇒ mixes across what the *model* deems reasonable (coherent, in-distribution
+  "chaos", unlike uniform noise).
+- **Checkpoint** — an earlier training step is a genuinely weaker, less-refined NFSP policy: a free
+  skill tier / literal "young" god (requires exporting that checkpoint, ~1.5 MB each).
+- **(Tier 3, deferred)** reward-shaped retraining for one flagship.
+
+So **personality = source (`π` / `Q` / weak checkpoint, or `cfr`, or the pure `conservative`
+heuristic) + `τ_model` + a bounded overlay + mood.** Strong gods (Perun, Svetovid, Mokosh, Veles)
+are NFSP-dominated with a light overlay; easy/funny gods (Leshy, Porevit, Czernobog) lean on the `Q`
+head, high `τ_model`, a weak checkpoint, or larger overlays. A deliberately-simple god (Domovoi) may
+bypass NFSP and route to `conservative_ai`.
+
+### Output overlay (bounded, secondary — applied to the chosen head's logits before selection)
+
+The 88 sets are ordered only by **seniority** — the legality ladder. On your turn you may bet a
+**strictly more senior** set than the last bet, or **check** (assert the last bet is false). There
+is no showdown/comparison; on a check, everyone reveals and the only question is whether the claimed
+set *exists among all pooled cards*. **Seniority index is NOT probability** — P(a set exists) is
+highly non-linear in the index, so knobs operate in **probability space**, never on the index.
+
+We use **two** probability vectors, both already in the repo:
+- **private** `p_priv(a) = get_bet_probabilities(game_state, for_betting=True, last_bet=...)` —
+  `P(set a exists | my hand, others' card counts)`; `specific_action_id=last` gives `p_priv(last)`
+  for the check decision.
+- **public** `pub_prior(a) = get_generic_bet_probabilities(game_state, ...)` — plausibility given
+  only public info (card counts, common cards, deck), already returned by `vectorize_obs`.
+
+The gap between them is strategically central: betting strictly along `p_priv` **leaks your hand**
+(the rules README names this tension — *"Alice doesn't want other players to know her cards"*).
+Betting along `pub_prior` is *concealing*: claims look generic and reveal little. The NFSP baseline
+already balances this near-equilibrium; the knobs deliberately distort it for character.
+
+| Knob | Meaning | Effect on logits |
+|---|---|---|
+| `risk` | honesty vs bluff (private) | bias bets by `−risk·z(p_priv(a))`: `risk>0` ⇒ bluffy (claims sets unlikely true → loses if checked), `risk<0` ⇒ honest (claims likely-true sets). Drives bluff *frequency* and *depth*. |
+| `guard` | concealment vs readability | bias bets by `+guard·z(pub_prior(a))`: `guard>0` ⇒ unreadable (bets to public expectation, hides the hand), `guard<0` ⇒ naive/leaky (bets its private truth openly → exploitable). |
+| `susp` | check threshold (private) | check when `p_priv(last) < θ(susp)`: `susp>0` ⇒ paranoid (challenges plausible bets), `susp<0` ⇒ trusting. Check-logit bias ∝ `(θ − p_priv(last))`. |
+| `tempo` | betting cadence | the **only** index-based knob, purely cadence: `tempo<0` ⇒ minimal legal raise (patient), `tempo>0` ⇒ big senior leaps. Not a truth proxy. |
+| `chaos` | randomness | raises `τ_model` (temperature on the head's *own* logits) + samples instead of argmax — coherent, in-distribution mixing, not uniform noise. |
+
+Total bet bias `= −risk·z(p_priv(a)) + guard·z(pub_prior(a))`. `z(·)` normalizes over the legal bets
+per state. Biases hit **legal** entries only, then the mask is re-applied (never lift an illegal
+action). Selection: `argmax` when `chaos == 0`, else sample at temperature τ.
+
+### Mood (stateless, derived from the per-move `game_state`)
+
+- `tilt` = my `n_cards` deficit vs table (behind ⇒ some bots tilt up, others tighten).
+- `phase` = total cards remaining / round number ⇒ early / mid / late knob sets.
+- `momentum` = recent round outcomes parsed from `history` ⇒ ramp after wins (Kupala).
+
+**Honest limits:** true cross-*game* opponent modelling ("this human bluffed 3 games ago") is NOT
+feasible — fixed policies don't learn you online. "Reader"/"manipulator" gods (Svetovid, Veles,
+Baba Yaga) are realized as *pseudo-adaptivity*: nudging knobs off `pub_prior` and the current
+round's `history`, not learning. Deeper authenticity for one flagship (Veles) is a deferred
+Tier-3 retrain, out of scope for v1.
+
+## The roster (v1 knob vectors, scale −2..+2; chaos 0..2)
+
+| Deity | Engine | Archetype | risk | guard | tempo | susp | chaos | Mood | Difficulty |
+|---|---|---|---|---|---|---|---|---|---|
+| **Morana** | CFR | Ice Queen | — | — | — | — | — | — (equilibrium) | Hard (wall) |
+| **Perun** | NFSP | Warlord | +1 | −0.5 | +1.5 | 0 | 0.2 | double-down after surviving a check | Hard |
+| Czernobog | NFSP | Terror | +2 | −0.5 | +1.5 | +0.5 | +1 | — | Med |
+| Svetovid | NFSP | Oracle | −0.5 | +1 | 0 | +1.5 | 0 | sharp check threshold on `p_priv(last)` | Hard |
+| Mokosh | NFSP | Weaver | −0.5 | +1 | −2 | +0.5 | 0 | tighten late | Med-Hard |
+| Triglav | NFSP | Strategist | phase | phase | phase | 0 | 0 | safe → base → aggressive by phase | Med-Hard |
+| Veles | NFSP | Serpent | phase | +2 | 0 | 0 | 0 | honest early → bluff late | Med-Hard |
+| Dazhbog | NFSP | King | +0.5 | 0 | +0.5 | −0.5 | 0 | suppress check when behind (ego) | Med |
+| Rusalka | NFSP | Siren | +1 | +1 | 0 | −0.5 | +0.3 | weak early → strike late | Med |
+| Mavka | NFSP | Illusion | +0.5 | +1.5 | 0 | −0.5 | +1 | — | Med |
+| Zorya | NFSP | Twins | ±1 by round | 0 | 0 | ±1 by round | +0.3 | dawn/dusk alternation by round parity | Med |
+| Kupala | NFSP | Reveler | +0.5 | −0.5 | 0 | 0 | +0.5 | ramp after wins, drop after losses | Med |
+| Baba Yaga | NFSP | Mind-gamer | +1 | +1 | spiky | +0.5 | +1.5 | structured "irrational" spikes | Med |
+| Poludnica | NFSP | Fever | phase | 0 | 0 | 0 | phase | passive → explosive spike late | Med |
+| Porevit | NFSP | Youth | +1 | −1.5 | −0.5 | 0 | +1.5 | chaos decays late ("learns") | Easy |
+| Leshy | NFSP | Trickster | +1 | 0 | 0 | 0 | +2 | per-move random chaos scaling | Easy |
+| Domovoi | NFSP | Caretaker | −1.5 | −1 | −1.5 | +0.5 | 0 | +susp vs over-claimers (trap) | Easy-Med |
+
+**Source overrides** (default head `π`): `Q` head — Perun, Czernobog, Dazhbog; weak checkpoint —
+Porevit; high `τ_model` — Leshy, Baba Yaga; pure `conservative_ai` (no NFSP) — Domovoi. Morana = `cfr`.
+
+(Values are the starting point; final tuning happens against the behavioral harness below.)
+
+## Implementation
+
+### A. AI repo (`blef_ai`) — sculpting mechanism (local, reversible)
+
+1. **`nfsp_ai/personalities.py`** (new):
+   - `@dataclass PersonalityConfig` — `source` (`pi`/`q`/`cfr`/`conservative` + optional checkpoint
+     id), `tau_model`, the overlay knobs (`risk`/`guard`/`susp`/`tempo`/`chaos`), + optional
+     mood/phase rules.
+   - `PERSONALITIES: dict[str, PersonalityConfig]` — the 16 NFSP entries (15 sculpted + Perun).
+     Missing/unknown id ⇒ `None` ⇒ baseline behavior (backward compatible).
+   - `derive_mood(game_state) -> dict` — stateless tilt/phase/momentum.
+   - `sculpt_logits(head_logits, mask, cfg, *, p_priv, pub_prior, p_last, deck_size, mood) ->
+     Tensor` — applies the bounded `risk`/`guard`/`susp`/`tempo` overlay (+
+     `GameRules(deck_size).check_action_id` for the check entry), then re-applies the mask.
+2. **`nfsp_ai/agent.py`** — add `policy_logits(obs, mask, *, head="pi", tau=1.0) -> Tensor`:
+   masked logits from the chosen head (`pi`→`self.pi`, `q`→`self.q`) at temperature `tau`. Refactor
+   `select_action` to reuse it. No behavior change to existing callers (defaults reproduce current).
+3. **`nfsp_ai/production_agent.py:410-479`** — in `determine_action`: read the current player's
+   `personality` from `game_state` (`players[cp].personality`); if absent/unknown ⇒ current greedy
+   path. Else fetch cfg, select head/`τ_model`/checkpoint, compute `policy_logits(..., head, tau)`,
+   then `p_priv = get_bet_probabilities(game_state, for_betting=True, last_bet=last)`, `p_last =
+   get_bet_probabilities(..., specific_action_id=last)`, reuse `pub_prior` from `vectorize_obs`
+   (line 460); pass to `sculpt_logits`, then argmax (`chaos==0`) or sample. `cfr`/`conservative`
+   sources delegate to those existing agents instead.
+
+### B. Game engine repo (`blef_game_engine`) — carry the personality (small change)
+
+- `api/invite-aiagent.py`: let an `AGENT_MAPPING` value be `{"agent_type": "...", "personality": "..."}`;
+  store `ai_agent = agent_type` (so the orchestrator still routes to `blef-aiagent-nfsp`/`-cfr`)
+  and add `"personality": personality` to the player object (lines ~64-71).
+- Set the `agent_mapping` env var: deity name → `{nfsp, <deity>}` for the 15 + Perun; Morana → `{cfr}`.
+- `api/aiagent-orchestrator.py`: **no change** — it already forwards the full game state, so the
+  new `personality` field reaches the lambda for free.
+
+### C. Deploy (no new ECR images)
+
+- AI: rebuild the single image via `nfsp_ai/scripts/deploy_lambda.sh`, push to the existing
+  `blef-nfsp-lambda` repo, update `blef-aiagent-nfsp`. CFR/Morana untouched.
+- Engine: redeploy `blef-invite-aiagent` and set the `agent_mapping` env var.
+- **Hold for explicit go-ahead** — commit/push and AWS deploy are high-blast-radius.
+
+## Verification
+
+1. **Behavioral harness** (local, reuse the sim in `nfsp_ai/nfsp_run_local.py`): run each
+   personality over a batch of states / self-play vs baseline and measure observable signatures —
+   challenge rate, bluff rate (mean `p_priv` of chosen bets), readability (mean `p_priv − pub_prior`
+   divergence of chosen bets), tempo (mean seniority jump), and win rate vs Perun. Assert each knob
+   moves its metric in the designed direction and that difficulty ordering holds (Perun/Morana
+   strongest; Leshy/Porevit weakest).
+2. **Unit**: `sculpt_logits` never assigns probability to a masked action; unknown personality ⇒
+   byte-identical to current baseline output.
+3. **Smoke**: `determine_action` on crafted game states with a `personality` field for several
+   deities → legal, distinct actions.
+4. **End-to-end** (post-deploy, test game): invite a deity, confirm orchestrator → `blef-aiagent-nfsp`
+   → legal move played.

--- a/nfsp_ai/agent.py
+++ b/nfsp_ai/agent.py
@@ -1894,11 +1894,27 @@ class NFSPAgent:
 
     # -------- Inference (usually average policy) --------
     @torch.no_grad()
+    def policy_logits(self, obs_vec: torch.Tensor, action_mask: torch.Tensor, *, head: str = "pi", tau: float = 1.0) -> torch.Tensor:
+        """Masked logits ``[1, A]`` from the chosen head at temperature ``tau``.
+
+        ``head`` selects ``"pi"`` (average policy — the Nash approximation used
+        in production) or ``"q"`` (best-response head — sharper, greedier).
+        ``tau`` is a softmax temperature applied to the head's own logits before
+        masking (``tau<1`` sharpens, ``tau>1`` flattens). Illegal actions are
+        set to ``-inf``. This is the shared core of :meth:`select_action`; the
+        defaults reproduce the legacy average-policy behaviour exactly.
+        """
+        net = self.pi if head == "pi" else self.q
+        logits = net(obs_vec.unsqueeze(0).to(self.device))
+        if tau is not None and float(tau) != 1.0:
+            logits = logits / float(tau)
+        mask = action_mask.unsqueeze(0).to(self.device)
+        return masked_softmax_logits(logits, mask)
+
+    @torch.no_grad()
     def select_action(self, obs_vec: torch.Tensor, action_mask: torch.Tensor, use_average_policy: bool = True, greedy: bool = False) -> int:
         if use_average_policy:
-            logits = self.pi(obs_vec.unsqueeze(0).to(self.device))
-            mask = action_mask.unsqueeze(0).to(self.device)
-            mlog = masked_softmax_logits(logits, mask)
+            mlog = self.policy_logits(obs_vec, action_mask, head="pi", tau=1.0)
             if greedy:
                 return int(mlog.argmax(dim=-1).item())
             dist = torch.distributions.Categorical(logits=mlog)

--- a/nfsp_ai/deployment/Dockerfile.lambda
+++ b/nfsp_ai/deployment/Dockerfile.lambda
@@ -10,6 +10,7 @@ RUN pip install --upgrade pip \
 COPY nfsp_ai ${LAMBDA_TASK_ROOT}/nfsp_ai
 COPY shared ${LAMBDA_TASK_ROOT}/shared
 COPY conservative_ai ${LAMBDA_TASK_ROOT}/conservative_ai
+COPY conservative_crawling_ai ${LAMBDA_TASK_ROOT}/conservative_crawling_ai
 COPY agent.py ${LAMBDA_TASK_ROOT}/agent.py
 COPY lambda_function.py ${LAMBDA_TASK_ROOT}/lambda_function.py
 COPY artifacts ${LAMBDA_TASK_ROOT}/artifacts

--- a/nfsp_ai/personalities.py
+++ b/nfsp_ai/personalities.py
@@ -1,0 +1,509 @@
+"""Play-style "personality" layer for the Blef NFSP production agent.
+
+A personality is *data*, not a new model: one shared set of NFSP weights is
+expressed as many distinct opponents by (1) choosing the policy *source*, then
+(2) applying a small, bounded *overlay* to that source's action logits, then
+(3) modulating the overlay with a stateless per-move *mood*. Morana (CFR) is a
+separate deployment and is intentionally absent here.
+
+Why this shape (and what it is NOT):
+  The overlay alone — biasing toward high/low-probability claims — is just a
+  parametrised conservative heuristic (cf. ``conservative_ai``). To get genuine
+  *NFSP-based* character the model is the PRIMARY axis and the overlay is a
+  bounded nudge on top, scaled to the policy's own logit spread so a strong
+  god stays NFSP-dominated and only a loud/quirky god lets the overlay show.
+
+Axes
+----
+source     "pi"  average policy  (balanced Nash approximation; prod default)
+           "q"   best-response head (sharper, greedier, more exploitable)
+           "conservative" / "conservative_crawling"  existing heuristic engines
+                 (delegated wholesale — a deliberately simple, different feel)
+tau_model  temperature on the chosen head's OWN logits (chaos knob); <1 sharpens
+risk       honesty<->bluff on the PRIVATE prob p_priv(a)=P(set exists | my hand)
+           risk>0 bluffy (claims unlikely-true sets), risk<0 honest
+guard      concealment<->readability on the divergence d(a)=p_priv(a)-pub(a)
+           guard>0 unreadable (avoids hand-revealing bets), guard<0 leaky/naive
+susp       check threshold on p_priv(last): susp>0 paranoid, susp<0 trusting
+tempo      betting cadence (index distance only, NOT a truth proxy):
+           tempo<0 minimal legal raise, tempo>0 big senior leaps
+mood       stateless modulation of the above, derived from the per-move state
+           (card standing, game depth, round parity, last-bet plausibility)
+
+Honest limits: fixed policies cannot model a specific opponent across games, so
+"reader"/"manipulator" gods are realised as probability-grounded heuristics +
+phase shifts, not online learning. Cross-round memory (tilt after a specific
+loss, multi-round traps) is unavailable; standing/depth proxies stand in.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+import torch
+
+from shared.game_utils import GameRules  # noqa: F401  (kept for callers/tests)
+from shared.probabilities.dynamic_probabilities import get_bet_probabilities
+from nfsp_ai.nfsp_run_local import _last_bet_action_id
+
+# --------------------------------------------------------------------------- #
+# Overlay gains. The overlay is added in LOG-PROBABILITY units on top of the
+# chosen head's (temperature-scaled) policy: a bias of +b multiplies an
+# action's probability by e^b before re-normalisation. This is head-agnostic
+# (pi vs q) and naturally bounded, so a confident NFSP move is nudged, not
+# overridden. Gains tuned against tools/personality_probe.py so that strong
+# gods stay NFSP-dominated and only loud/quirky gods visibly deviate.
+# --------------------------------------------------------------------------- #
+BETA = 0.40          # global overlay gain (log-prob units)
+TEMPO_W = 0.7        # cadence weight inside the bet bias
+CHECK_W = 1.5        # suspicion weight on the check action
+SUSP_THETA = 0.5     # neutral check threshold on p_priv(last)
+Z_CLIP = 2.5         # clip on standardized probability features
+BIAS_CLIP = 3.0      # clip on the total per-action bias (log-prob units)
+# Chaos = in-distribution top-k sampling over the SCULPTED policy (never
+# uniform/random): keep the k best actions and mix among them with a mild
+# in-set temperature. Temperature on the raw head was discarded — the NFSP
+# policy is so peaked that any tau>~1.2 collapses it toward uniform and the
+# bot just plays random senior bluffs (see tools/personality_probe.py diag).
+KC = 2.0             # chaos -> extra top-k actions:  k = round(1 + KC*chaos)
+TIN = 0.7            # chaos -> in-set temperature:   tau = 1 + TIN*chaos
+
+
+@dataclass(frozen=True)
+class PersonalityConfig:
+    source: str = "pi"
+    risk: float = 0.0
+    guard: float = 0.0
+    susp: float = 0.0
+    tempo: float = 0.0
+    chaos: float = 0.0
+    mood: str = "none"
+    mood_params: dict = field(default_factory=dict)
+    note: str = ""  # design rationale (also usable as flavor/debug text)
+
+
+@dataclass
+class EffectiveCfg:
+    source: str
+    risk: float
+    guard: float
+    susp: float
+    tempo: float
+    chaos: float
+    tau_model: float
+    sample: bool
+
+
+_DELEGATED_SOURCES = {"conservative", "conservative_crawling", "cfr"}
+
+
+# --------------------------------------------------------------------------- #
+# The pantheon (Morana = CFR, deployed separately, intentionally not here).
+# Knob scale is roughly [-2, +2]; difficulty falls out of distance from the
+# baseline's near-equilibrium balance (bigger distortion ⇒ more exploitable).
+# --------------------------------------------------------------------------- #
+PERSONALITIES: dict[str, PersonalityConfig] = {
+    # --- The difficulty wall: SOTA, lightly tinted -------------------------- #
+    "perun": PersonalityConfig(
+        source="q", risk=0.15, guard=-0.15, susp=-0.1, tempo=0.2, chaos=0.0,
+        mood="standing_push", mood_params={"k": 0.35},
+        note="Warlord. Best-response (Q) head is itself the decisive/greedy "
+             "voice; only a light overlay on top (the Q head is overlay-"
+             "sensitive). Pushes a little harder when ahead. The wall: "
+             "near-NFSP strength, faintly bold.",
+    ),
+    # --- Aggressors -------------------------------------------------------- #
+    "czernobog": PersonalityConfig(
+        source="pi", risk=1.5, guard=-0.4, susp=0.3, tempo=0.4, chaos=0.9,
+        mood="none",
+        note="Terror. The loudest aggressor: high-risk pressure on the "
+             "(controllable) pi head, volatile and readable (low guard); can "
+             "implode (high risk+chaos) but the overlay is bounded so it stays "
+             "a live opponent, not a free win.",
+    ),
+    "dazhbog": PersonalityConfig(
+        source="pi", risk=0.7, guard=0.1, susp=-0.3, tempo=0.2, chaos=0.3,
+        mood="ego_behind", mood_params={"k": -1.0},
+        note="King. Proud 'noble' bluffs; rarely checks and pride makes him "
+             "refuse to challenge even when behind (ego-driven misreads). On "
+             "the pi head so the bluff magnitude stays controlled.",
+    ),
+    # --- Disciplined / strong --------------------------------------------- #
+    "svetovid": PersonalityConfig(
+        source="pi", risk=-0.4, guard=1.0, susp=1.2, tempo=0.0, chaos=-0.3,
+        mood="none",
+        note="Oracle. Disciplined and unreadable (high guard, sharp tau); "
+             "calls implausible bets hard via the p_priv(last) threshold — "
+             "real probability-grounded 'reading', not faked adaptivity.",
+    ),
+    "mokosh": PersonalityConfig(
+        source="pi", risk=-0.4, guard=0.8, susp=0.4, tempo=-1.5, chaos=-0.2,
+        mood="tighten_late", mood_params={"kr": 0.8, "ks": 0.8},
+        note="Weaver. Measured minimal raises, concealed; tightens and grows "
+             "more suspicious as the game deepens (dangerous late).",
+    ),
+    "triglav": PersonalityConfig(
+        source="pi", risk=0.0, guard=0.3, susp=0.0, tempo=0.0, chaos=0.0,
+        mood="phase_ramp",
+        mood_params={"risk_early": -0.8, "risk_late": 1.0,
+                     "tempo_early": -1.0, "tempo_late": 1.0,
+                     "guard_early": 0.5, "guard_late": 0.0},
+        note="Strategist. Three modes by game depth: conservative early, "
+             "analytical mid, aggressive late ('all paths converge').",
+    ),
+    "veles": PersonalityConfig(
+        source="pi", risk=0.0, guard=1.8, susp=0.0, tempo=0.0, chaos=0.0,
+        mood="phase_ramp",
+        mood_params={"risk_early": -1.0, "risk_late": 1.6,
+                     "guard_early": 1.8, "guard_late": 1.8},
+        note="Serpent. Maximally unreadable; honest early to build a false "
+             "pattern, then bluffs late ('truth is the longest bluff'). "
+             "True cross-round traps need memory we lack — phase-shift proxy.",
+    ),
+    # --- Deceivers / mid ---------------------------------------------------- #
+    "rusalka": PersonalityConfig(
+        source="pi", risk=0.3, guard=1.0, susp=-0.5, tempo=0.0, chaos=0.2,
+        mood="phase_ramp",
+        mood_params={"risk_early": 0.2, "risk_late": 1.3,
+                     "guard_early": 1.0, "guard_late": 1.0},
+        note="Siren. Appears modest and passive (low risk, rarely checks), "
+             "tells believable lies (high guard), then strikes late once "
+             "opponents have overextended ('come closer').",
+    ),
+    "mavka": PersonalityConfig(
+        source="pi", risk=0.3, guard=1.2, susp=-0.4, tempo=0.0, chaos=0.6,
+        mood="none",
+        note="Illusion. Ambiguous, contradictory signals (high guard + chaos), "
+             "passive checking; hard to read but can drift passive ('did you "
+             "imagine me?').",
+    ),
+    "zorya": PersonalityConfig(
+        source="pi", risk=0.15, guard=0.0, susp=0.15, tempo=0.0, chaos=0.2,
+        mood="parity_swing", mood_params={"d": 0.8},
+        note="Twins. Dawn (even rounds): trusting + aggressive. Dusk (odd): "
+             "suspicious + defensive. Alternates each round (round parity), so "
+             "the state shift is real and learnable ('dawn promises, dusk "
+             "remembers').",
+    ),
+    "kupala": PersonalityConfig(
+        source="pi", risk=0.3, guard=-0.5, susp=0.0, tempo=0.0, chaos=0.4,
+        mood="win_ramp", mood_params={"k": 0.9, "kc": 0.6},
+        note="Reveler. Momentum player: snowballs (more risk + chaos) while "
+             "ahead, tilts down when behind. Standing (card lead) is the "
+             "stateless proxy for 'winning' ('dance while the fire burns').",
+    ),
+    "baba_yaga": PersonalityConfig(
+        source="pi", risk=0.6, guard=0.8, susp=0.4, tempo=0.0, chaos=0.5,
+        mood="spike_random",
+        mood_params={"thr": 0.68, "chaos_spike": 1.2, "tempo_spike": 1.5,
+                     "risk_spike": 0.6},
+        note="Mind-gamer. Mostly composed, but deterministic per-state spikes "
+             "throw sudden 'irrational' high-tempo bluffs to bait reactions "
+             "('you came to my forest willingly').",
+    ),
+    "poludnica": PersonalityConfig(
+        source="pi", risk=0.0, guard=0.0, susp=0.0, tempo=0.0, chaos=0.0,
+        mood="spike_late",
+        mood_params={"thr": 0.55, "risk_spike": 1.8, "chaos_spike": 1.0,
+                     "tempo_spike": 1.2, "risk_calm": -0.6, "chaos_calm": -0.2},
+        note="Fever. Long passive (honest, decisive) stretches, then abrupt "
+             "violent escalation once the game deepens. Predictable spike "
+             "timing is the weakness ('the heat breaks weaker minds').",
+    ),
+    # --- Easy / chaotic / fun ---------------------------------------------- #
+    "porevit": PersonalityConfig(
+        source="pi", risk=0.9, guard=-1.2, susp=0.0, tempo=-0.4, chaos=1.3,
+        mood="chaos_decay", mood_params={"k": 1.2},
+        note="Youth. Impulsive, leaky (low guard) and experimental (high "
+             "chaos), 'learns' within a game as chaos decays with depth "
+             "('why not try?'). Inconsistent ⇒ easy.",
+    ),
+    "leshy": PersonalityConfig(
+        source="pi", risk=0.8, guard=0.0, susp=0.0, tempo=0.0, chaos=0.4,
+        mood="random_chaos", mood_params={"base": 0.4, "amp": 1.8},
+        note="Trickster. Per-move chaos swings between genius and nonsense; "
+             "self-destructive randomness ('lost already?'). Easiest NFSP god.",
+    ),
+    # --- Heuristic engine (no NFSP): genuinely different feel --------------- #
+    "domovoi": PersonalityConfig(
+        source="conservative_crawling",
+        note="Caretaker. Delegated to the conservative-crawling heuristic "
+             "(safe, plausible, team-aware, low-variance). Appears harmless "
+             "and is too readable for strong players ('a quiet house hides "
+             "many things').",
+    ),
+}
+
+PERSONALITY_NAMES = sorted(PERSONALITIES)
+
+
+# --------------------------------------------------------------------------- #
+# Small helpers
+# --------------------------------------------------------------------------- #
+def _clamp(x: float, lo: float, hi: float) -> float:
+    return lo if x < lo else hi if x > hi else x
+
+
+def _lerp(a: float, b: float, t: float) -> float:
+    return a + (b - a) * _clamp(t, 0.0, 1.0)
+
+
+def _z(arr: np.ndarray) -> np.ndarray:
+    """Standardize and clip; zeros when degenerate (constant / singleton)."""
+    if arr.size <= 1:
+        return np.zeros_like(arr)
+    s = float(arr.std())
+    if s < 1e-9:
+        return np.zeros_like(arr)
+    return np.clip((arr - float(arr.mean())) / s, -Z_CLIP, Z_CLIP)
+
+
+def _state_hash(game_state: dict) -> float:
+    """Deterministic per-move pseudo-random value in [0, 1).
+
+    Keyed on the current round's bet history + actor + round so a god's
+    "random" behaviour is reproducible for a given decision point (not
+    re-rolled on retries) yet varies move to move.
+    """
+    hist = game_state.get("history", []) or []
+    ids = ",".join(str((h or {}).get("action_id", "")) for h in hist)
+    key = f"{ids}#{game_state.get('cp_nickname', '')}#{game_state.get('round_number', 0)}"
+    digest = hashlib.md5(key.encode("utf-8")).hexdigest()
+    return (int(digest[:8], 16) % 100000) / 100000.0
+
+
+def _mood_signals(game_state: dict) -> dict:
+    """Stateless mood signals derived purely from the current game state.
+
+    depth     [0,1] game progression (mean active hand size; everyone starts
+              at 1 card and the loser accrues a card each round).
+    standing  [-1,1] my position; >0 means I hold FEWER cards than rivals
+              (i.e., I am winning) — the only stateless proxy for momentum.
+    parity    round_number % 2 (flips most rounds: the loser gains a card).
+    """
+    players = game_state.get("players", []) or []
+    cp = game_state.get("cp_nickname")
+    active = [int(p.get("n_cards", 0)) for p in players if int(p.get("n_cards", 0)) > 0]
+    avg = (sum(active) / len(active)) if active else 1.0
+    my = next((int(p.get("n_cards", 0)) for p in players if p.get("nickname") == cp), 0)
+    others = [int(p.get("n_cards", 0)) for p in players
+              if p.get("nickname") != cp and int(p.get("n_cards", 0)) > 0]
+    avg_others = (sum(others) / len(others)) if others else float(my)
+    cap = 6.0
+    depth = _clamp((avg - 1.0) / (cap - 1.0), 0.0, 1.0)
+    standing = _clamp((avg_others - my) / cap, -1.0, 1.0)
+    parity = int(game_state.get("round_number", 1) or 1) % 2
+    return {"depth": depth, "standing": standing, "parity": parity}
+
+
+def derive_effective_cfg(cfg: PersonalityConfig, signals: dict, p_last: float,
+                         state_r: float) -> EffectiveCfg:
+    """Apply the personality's mood rule to its base knobs for this move."""
+    risk, guard, susp, tempo, chaos = cfg.risk, cfg.guard, cfg.susp, cfg.tempo, cfg.chaos
+    m, pr = cfg.mood, (cfg.mood_params or {})
+    depth, standing, parity = signals["depth"], signals["standing"], signals["parity"]
+
+    if m == "phase_ramp":
+        risk = _lerp(pr.get("risk_early", risk), pr.get("risk_late", risk), depth)
+        guard = _lerp(pr.get("guard_early", guard), pr.get("guard_late", guard), depth)
+        tempo = _lerp(pr.get("tempo_early", tempo), pr.get("tempo_late", tempo), depth)
+        chaos = _lerp(pr.get("chaos_early", chaos), pr.get("chaos_late", chaos), depth)
+    elif m == "standing_push":
+        if standing > 0:
+            risk += pr.get("k", 1.0) * standing
+            tempo += pr.get("k", 1.0) * standing
+    elif m == "win_ramp":
+        risk += pr.get("k", 1.0) * standing
+        if standing > 0:
+            chaos += pr.get("kc", 0.5) * standing
+    elif m == "spike_late":
+        if depth >= pr.get("thr", 0.55):
+            risk = pr.get("risk_spike", 2.0)
+            chaos = pr.get("chaos_spike", 1.0)
+            tempo = pr.get("tempo_spike", 1.0)
+        else:
+            risk = pr.get("risk_calm", -0.5)
+            chaos = pr.get("chaos_calm", -0.2)
+    elif m == "tighten_late":
+        risk -= pr.get("kr", 1.0) * depth
+        susp += pr.get("ks", 1.0) * depth
+    elif m == "chaos_decay":
+        chaos -= pr.get("k", 1.5) * depth
+    elif m == "ego_behind":
+        if standing < 0:
+            susp += pr.get("k", -1.5) * abs(standing)
+    elif m == "trap_overclaim":
+        if p_last is not None and p_last < pr.get("thr", 0.35):
+            susp += pr.get("k", 1.5)
+    elif m == "parity_swing":
+        d = pr.get("d", 1.0)
+        if parity == 0:
+            risk += d
+            susp -= d
+        else:
+            risk -= d
+            susp += d
+    elif m == "spike_random":
+        if state_r > pr.get("thr", 0.7):
+            chaos += pr.get("chaos_spike", 1.0)
+            tempo += pr.get("tempo_spike", 1.5)
+            risk += pr.get("risk_spike", 0.5)
+    elif m == "random_chaos":
+        chaos = pr.get("base", 0.5) + pr.get("amp", 1.8) * state_r
+
+    risk = _clamp(risk, -3.0, 3.0)
+    guard = _clamp(guard, -3.0, 3.0)
+    susp = _clamp(susp, -3.0, 3.0)
+    tempo = _clamp(tempo, -3.0, 3.0)
+    chaos = _clamp(chaos, -1.0, 2.5)
+    return EffectiveCfg(
+        source=cfg.source, risk=risk, guard=guard, susp=susp, tempo=tempo,
+        chaos=chaos, tau_model=1.0, sample=chaos > 0.05,
+    )
+
+
+def sculpt_logits(logits: torch.Tensor, mask: torch.Tensor, eff: EffectiveCfg, *,
+                  pvt, pub, p_last: float, check_id: int) -> torch.Tensor:
+    """Add the bounded overlay to the chosen head's masked logits.
+
+    ``logits``/``mask`` are ``[1, A]``. Bets are ids ``[0, check_id)``; the
+    check action is at ``check_id``. ``pvt``/``pub`` are length-``check_id``
+    probability vectors (private / public) already zeroed below the last bet.
+    The chosen head is converted to log-probabilities and the overlay is added
+    there (a bias of +b ⇒ ×e^b on that action's probability), clipped, so a
+    confident NFSP move is nudged rather than overridden. Illegal actions stay
+    ``-inf``.
+    """
+    m = mask.reshape(-1)
+    legal = m > 0
+    A = logits.shape[-1]
+    neg_inf = torch.finfo(logits.dtype).min
+
+    logp = torch.log_softmax(logits, dim=-1)
+    row = logp[0]
+    bias = torch.zeros(A, dtype=logp.dtype, device=logp.device)
+
+    legal_idx = [i for i in range(min(check_id, A)) if bool(legal[i].item())]
+    if legal_idx:
+        pvt_a = np.array([float(pvt[i]) for i in legal_idx], dtype=np.float64)
+        pub_a = np.array([float(pub[i]) for i in legal_idx], dtype=np.float64)
+        z_pvt = _z(pvt_a)
+        z_div = _z(pvt_a - pub_a)
+        if len(legal_idx) > 1:
+            lo, hi = legal_idx[0], legal_idx[-1]
+            rng = max(1, hi - lo)
+            rank = (np.array(legal_idx, dtype=np.float64) - lo) / rng
+            tempo_term = (rank - 0.5) * 2.0
+        else:
+            tempo_term = np.zeros(1, dtype=np.float64)
+        bet_bias = BETA * (
+            -eff.risk * z_pvt - eff.guard * z_div + eff.tempo * TEMPO_W * tempo_term
+        )
+        bet_bias = np.clip(bet_bias, -BIAS_CLIP, BIAS_CLIP)
+        for k, i in enumerate(legal_idx):
+            bias[i] = float(bet_bias[k])
+
+    if check_id < A and bool(legal[check_id].item()):
+        cb = BETA * eff.susp * CHECK_W * (SUSP_THETA - float(p_last)) * 2.0
+        bias[check_id] = float(np.clip(cb, -BIAS_CLIP, BIAS_CLIP))
+
+    out = (row + bias).unsqueeze(0)
+    return out.masked_fill(m == 0, neg_inf)
+
+
+def _select(sculpted: torch.Tensor, chaos: float) -> int:
+    """Pick an action from the sculpted policy.
+
+    chaos<=0 → argmax (decisive). chaos>0 → coherent in-distribution sampling:
+    keep the top ``k = round(1 + KC*chaos)`` actions of the sculpted policy and
+    sample among them with a mild in-set temperature. The bot only ever varies
+    among moves it already rates highly — never a uniform-random senior bluff.
+    """
+    if chaos <= 0.05:
+        return int(sculpted.argmax(dim=-1).item())
+    probs = torch.softmax(sculpted, dim=-1).reshape(-1)
+    nz = int((probs > 0).sum().item())
+    if nz <= 1:
+        return int(probs.argmax().item())
+    k = min(nz, max(2, int(round(1 + KC * chaos))))
+    topv, topi = probs.topk(k)
+    tau = 1.0 + TIN * chaos
+    w = topv.double().clamp_min(1e-12) ** (1.0 / tau)
+    total = float(w.sum())
+    if total <= 0:
+        return int(topi[0].item())
+    j = int(torch.multinomial(w / w.sum(), 1).item())
+    return int(topi[j].item())
+
+
+# --------------------------------------------------------------------------- #
+# Entry points used by the production agent
+# --------------------------------------------------------------------------- #
+def resolve_personality(game_state: dict) -> Optional[str]:
+    """Resolve the personality id for the current player, or None.
+
+    Order: explicit ``personality`` on the current player, then a top-level
+    ``personality`` field, then a prefix match against the actor's nickname
+    (e.g. ``"perun_(AI)"`` / ``"veles_2_(AI)"``). The nickname fallback lets the
+    image work with only an ``agent_mapping`` env change (no engine code change).
+    """
+    cp = game_state.get("cp_nickname")
+    players = game_state.get("players") or []
+    cur = next((p for p in players if p.get("nickname") == cp), None)
+    cand = (cur or {}).get("personality") or game_state.get("personality")
+    if cand:
+        key = str(cand).strip().lower()
+        if key in PERSONALITIES:
+            return key
+    if cp:
+        nl = str(cp).strip().lower()
+        best = None
+        for key in PERSONALITIES:
+            if nl.startswith(key) and (best is None or len(key) > len(best)):
+                best = key
+        if best:
+            return best
+    return None
+
+
+def _delegate(source: str, game_state: dict) -> int:
+    """Delegate the move to an existing heuristic/CFR engine (lazy import)."""
+    if source == "conservative_crawling":
+        from conservative_crawling_ai.agent import ConservativeCrawlingAgent
+        return int(ConservativeCrawlingAgent.determine_action(game_state))
+    if source == "conservative":
+        from conservative_ai.agent import ConservativeAgent
+        return int(ConservativeAgent.determine_action(game_state))
+    if source == "cfr":
+        from cfr_ai.agent import determine_action as cfr_determine_action
+        return int(cfr_determine_action(game_state))
+    raise ValueError(f"Unknown delegated source: {source}")
+
+
+def is_delegated(name: str) -> bool:
+    cfg = PERSONALITIES.get(name)
+    return bool(cfg and cfg.source in _DELEGATED_SOURCES)
+
+
+def personality_action(agent, obs_tensor: torch.Tensor, mask_tensor: torch.Tensor,
+                       game_state: dict, spec, pub_prior, name: str) -> int:
+    """Compute the action for personality ``name`` over the chosen NFSP head."""
+    cfg = PERSONALITIES[name]
+    signals = _mood_signals(game_state)
+    last_bet_id = _last_bet_action_id(game_state, spec)
+    p_last = float(get_bet_probabilities(
+        game_state=game_state, for_betting=False, specific_action_id=last_bet_id))
+    state_r = _state_hash(game_state)
+    eff = derive_effective_cfg(cfg, signals, p_last, state_r)
+
+    head = "q" if eff.source == "q" else "pi"
+    logits = agent.policy_logits(obs_tensor, mask_tensor, head=head, tau=1.0)
+    pvt = get_bet_probabilities(game_state=game_state, for_betting=True, last_bet=last_bet_id)
+    sculpted = sculpt_logits(
+        logits, mask_tensor, eff,
+        pvt=pvt, pub=pub_prior, p_last=p_last, check_id=int(spec.check_action_id),
+    )
+    return _select(sculpted, eff.chaos)

--- a/nfsp_ai/production_agent.py
+++ b/nfsp_ai/production_agent.py
@@ -9,6 +9,7 @@ alongside optional card/history embedding artifacts.  It exposes a single helper
 from __future__ import annotations
 
 import glob
+import logging
 import os
 import re
 from dataclasses import replace
@@ -18,6 +19,7 @@ from typing import Optional, Tuple
 import numpy as np
 import torch
 
+from nfsp_ai import personalities
 from nfsp_ai.agent import NFSPAgent, NFSPConfig
 from nfsp_ai.nfsp_run_local import (
     _deck_spec_from_game,
@@ -29,6 +31,8 @@ from nfsp_ai.nfsp_run_local import (
     HistoryEmbeddingRuntime,
 )
 from shared.game_utils import GameRules
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Defaults (override via environment variables in Lambda / CLI wrappers)
@@ -415,6 +419,13 @@ class NFSPProductionAgent:
         if not cp:
             raise ValueError("Game state missing 'cp_nickname'")
 
+        # Personality routing. Delegated sources (heuristic / CFR engines) need
+        # no NFSP checkpoint and run on the original (un-canonicalized) state.
+        pers_name = personalities.resolve_personality(game_state)
+        if pers_name is not None and personalities.is_delegated(pers_name):
+            return int(personalities._delegate(
+                personalities.PERSONALITIES[pers_name].source, game_state))
+
         rules = game_state.get("rules", {}) or {}
         deck_size = int(rules.get("deck_size", 24))
         players = game_state.get("players", []) or []
@@ -470,6 +481,18 @@ class NFSPProductionAgent:
 
         obs_tensor = torch.from_numpy(np.asarray(obs_vec, dtype=np.float32)).to(self.device)
         mask_tensor = mask.to(device=self.device, dtype=torch.float32)
+
+        # NFSP-backed personality: sculpt the chosen head's logits. Any failure
+        # falls back to the unmodified baseline policy so a bad config can never
+        # take a bot offline.
+        if pers_name is not None:
+            try:
+                return int(personalities.personality_action(
+                    agent, obs_tensor, mask_tensor, game_state, spec, pub_prior, pers_name))
+            except Exception:
+                logger.exception(
+                    "personality_action failed for '%s'; using baseline policy", pers_name)
+
         action = agent.select_action(
             obs_tensor,
             mask_tensor,

--- a/nfsp_ai/scripts/deploy_lambda.sh
+++ b/nfsp_ai/scripts/deploy_lambda.sh
@@ -58,6 +58,7 @@ cp "${NFSP_DIR}/production_agent.py" "${TEMP_DIR}/agent.py"
 cp "${ROOT_DIR}/deployment/lambda_function.py" "${TEMP_DIR}/lambda_function.py"
 rsync -a "${ROOT_DIR}/artifacts/" "${TEMP_DIR}/artifacts/"
 rsync -a --exclude '__pycache__' "${ROOT_DIR}/conservative_ai" "${TEMP_DIR}/"
+rsync -a --exclude '__pycache__' "${ROOT_DIR}/conservative_crawling_ai" "${TEMP_DIR}/"
 
 cp "${NFSP_DIR}/deployment/requirements.txt" "${TEMP_DIR}/requirements.txt"
 cp "${NFSP_DIR}/deployment/Dockerfile.lambda" "${TEMP_DIR}/Dockerfile"
@@ -80,9 +81,15 @@ echo "[push] Pushing ${ECR}"
 docker push "${ECR}"
 
 FUNCTION="${FUNCTION:-blef-aiagent-nfsp}"
-echo "[lambda] Updating Lambda function ${FUNCTION} to image ${ECR}"
-aws lambda update-function-code \
-  --function-name "${FUNCTION}" \
-  --image-uri "${ECR}"
-
-echo "[done] Deployment complete."
+# The function swap is gated behind SWAP=1 so build+push can be done without
+# touching production. Swap explicitly (SWAP=1) once the new image is verified.
+if [[ "${SWAP:-0}" == "1" ]]; then
+  echo "[lambda] Updating Lambda function ${FUNCTION} to image ${ECR}"
+  aws lambda update-function-code \
+    --function-name "${FUNCTION}" \
+    --image-uri "${ECR}"
+  echo "[done] Build, push and SWAP complete."
+else
+  echo "[skip] SWAP!=1 — pushed image ${ECR} but did NOT update ${FUNCTION}."
+  echo "       To swap:  aws lambda update-function-code --function-name ${FUNCTION} --image-uri ${ECR} --region ${REGION}"
+fi

--- a/tests/test_personalities.py
+++ b/tests/test_personalities.py
@@ -1,0 +1,201 @@
+"""Unit + smoke tests for the personality layer (nfsp_ai/personalities.py)."""
+
+import os
+import unittest
+
+import numpy as np
+import torch
+
+from nfsp_ai import personalities as P
+from shared.game_utils import GameRules
+
+
+# --------------------------------------------------------------------------- #
+# Pure-function tests (no model needed)
+# --------------------------------------------------------------------------- #
+class SculptTest(unittest.TestCase):
+    def _cfg(self, **kw):
+        base = dict(source="pi", risk=0.0, guard=0.0, susp=0.0, tempo=0.0,
+                    chaos=0.0, tau_model=1.0, sample=False)
+        base.update(kw)
+        return P.EffectiveCfg(**base)
+
+    def _legal_mask(self, A, legal_idx):
+        m = torch.zeros(A)
+        for i in legal_idx:
+            m[i] = 1.0
+        return m
+
+    def test_illegal_actions_stay_neg_inf(self):
+        A, check = 89, 88
+        logits = torch.randn(1, A)
+        legal = [3, 4, 5, 60, check]      # a few bets + check
+        mask = self._legal_mask(A, legal)
+        pvt = [0.2] * check
+        pub = [0.1] * check
+        out = P.sculpt_logits(logits, mask, self._cfg(risk=1.5, susp=1.0, tempo=1.0),
+                              pvt=pvt, pub=pub, p_last=0.2, check_id=check)
+        illegal = [i for i in range(A) if i not in legal]
+        self.assertTrue(torch.isinf(out[0, illegal]).all() or
+                        (out[0, illegal] <= torch.finfo(out.dtype).min / 2).all())
+        # softmax puts ~zero mass on illegal and the chosen action is legal
+        probs = torch.softmax(out, dim=-1)[0]
+        self.assertLess(float(probs[illegal].sum()), 1e-6)
+        self.assertIn(int(out.argmax(-1).item()), legal)
+
+    def test_risk_sign_makes_bluffier(self):
+        # Higher risk should shift mass toward lower-pPriv (improbable) bets.
+        A, check = 89, 88
+        logits = torch.zeros(1, A)        # flat policy isolates the overlay
+        legal_idx = list(range(10, 40))
+        mask = self._legal_mask(A, legal_idx)
+        # pvt decreasing with index (senior bets less probable); pub flat
+        pvt = [0.0] * check
+        for r, i in enumerate(legal_idx):
+            pvt[i] = 1.0 - r / len(legal_idx)
+        pub = [0.3] * check
+        honest = P.sculpt_logits(logits, mask, self._cfg(risk=-1.5),
+                                 pvt=pvt, pub=pub, p_last=0.2, check_id=check)
+        bluffy = P.sculpt_logits(logits, mask, self._cfg(risk=+1.5),
+                                 pvt=pvt, pub=pub, p_last=0.2, check_id=check)
+        # expected pPriv of the argmax bet
+        self.assertGreater(pvt[int(honest.argmax(-1))], pvt[int(bluffy.argmax(-1))])
+
+    def test_susp_boosts_check_when_implausible(self):
+        A, check = 89, 88
+        logits = torch.zeros(1, A)
+        legal_idx = [20, 21, 22, check]
+        mask = self._legal_mask(A, legal_idx)
+        pvt = [0.5] * check
+        pub = [0.5] * check
+        # last bet very implausible (p_last low) + paranoid -> check boosted
+        out = P.sculpt_logits(logits, mask, self._cfg(susp=2.0),
+                              pvt=pvt, pub=pub, p_last=0.05, check_id=check)
+        self.assertEqual(int(out.argmax(-1).item()), check)
+        # trusting bot with same state should not jump to check
+        out2 = P.sculpt_logits(logits, mask, self._cfg(susp=-2.0),
+                               pvt=pvt, pub=pub, p_last=0.05, check_id=check)
+        self.assertNotEqual(int(out2.argmax(-1).item()), check)
+
+
+class SelectTest(unittest.TestCase):
+    def test_argmax_when_no_chaos(self):
+        logits = torch.tensor([[0.1, 5.0, 0.2, float("-inf")]])
+        self.assertEqual(P._select(logits, chaos=0.0), 1)
+
+    def test_sampling_stays_in_distribution(self):
+        torch.manual_seed(0)
+        # one strong + a few weak legal; chaos should sample only among top-k
+        logits = torch.tensor([[3.0, 2.5, 2.0, -5.0, float("-inf")]])
+        picks = {P._select(logits, chaos=1.0) for _ in range(200)}
+        self.assertTrue(picks.issubset({0, 1, 2}))   # never the clearly-bad 3 or illegal 4
+        self.assertNotIn(4, picks)
+
+
+class ResolveTest(unittest.TestCase):
+    def _state(self, cp, players_extra=None):
+        players = [{"nickname": cp, "n_cards": 1}]
+        if players_extra:
+            players[0].update(players_extra)
+        return {"cp_nickname": cp, "players": players}
+
+    def test_explicit_field(self):
+        s = self._state("whoever", {"personality": "Veles"})
+        self.assertEqual(P.resolve_personality(s), "veles")
+
+    def test_nickname_fallback(self):
+        self.assertEqual(P.resolve_personality(self._state("perun_(AI)")), "perun")
+        self.assertEqual(P.resolve_personality(self._state("veles_2_(AI)")), "veles")
+
+    def test_unknown_returns_none(self):
+        self.assertIsNone(P.resolve_personality(self._state("p0")))
+        self.assertIsNone(P.resolve_personality(self._state("randomname")))
+
+    def test_every_god_resolvable_and_typed(self):
+        self.assertEqual(len(P.PERSONALITIES), 16)
+        self.assertNotIn("morana", P.PERSONALITIES)  # CFR, deployed separately
+        for name, cfg in P.PERSONALITIES.items():
+            self.assertIn(cfg.source, {"pi", "q", "conservative", "conservative_crawling", "cfr"})
+
+
+class MoodTest(unittest.TestCase):
+    def test_phase_ramp_interpolates(self):
+        cfg = P.PersonalityConfig(source="pi", mood="phase_ramp",
+                                  mood_params={"risk_early": -1.0, "risk_late": 1.0})
+        early = P.derive_effective_cfg(cfg, {"depth": 0.0, "standing": 0.0, "parity": 0}, 0.5, 0.5)
+        late = P.derive_effective_cfg(cfg, {"depth": 1.0, "standing": 0.0, "parity": 0}, 0.5, 0.5)
+        self.assertAlmostEqual(early.risk, -1.0, places=5)
+        self.assertAlmostEqual(late.risk, 1.0, places=5)
+
+    def test_parity_swing_flips(self):
+        cfg = P.PERSONALITIES["zorya"]
+        dawn = P.derive_effective_cfg(cfg, {"depth": 0.3, "standing": 0.0, "parity": 0}, 0.5, 0.5)
+        dusk = P.derive_effective_cfg(cfg, {"depth": 0.3, "standing": 0.0, "parity": 1}, 0.5, 0.5)
+        self.assertGreater(dawn.risk, dusk.risk)   # dawn aggressive
+        self.assertLess(dawn.susp, dusk.susp)       # dusk suspicious
+
+    def test_state_hash_deterministic(self):
+        s = {"history": [{"action_id": 3}], "cp_nickname": "x", "round_number": 2}
+        self.assertEqual(P._state_hash(s), P._state_hash(dict(s)))
+
+
+# --------------------------------------------------------------------------- #
+# Model smoke tests (load the production agent once)
+# --------------------------------------------------------------------------- #
+def _have_artifacts():
+    import glob
+    return bool(glob.glob("artifacts/nfsp_inference_*.pt"))
+
+
+@unittest.skipUnless(_have_artifacts(), "inference artifacts not present")
+class PersonalityActionSmokeTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from nfsp_ai import production_agent as pa
+        cls.agent = pa.load_agent()
+
+    def _state(self, deck=24, n=2, k=1, last_bet=2, personality=None):
+        vals = 6 if deck == 24 else 8
+        cards = [(v, c) for v in range(vals) for c in range(4)]
+        hands_cards = [cards[i * k:(i + 1) * k] for i in range(n)]
+        names = [f"p{i}" for i in range(n)]
+        players = [{"nickname": names[i], "n_cards": k, "team": None} for i in range(n)]
+        if personality is not None:
+            players[0]["personality"] = personality
+        hands = [{"nickname": names[i],
+                  "hand": [{"value": v, "colour": c} for (v, c) in hands_cards[i]]}
+                 for i in range(n)]
+        hist = [] if last_bet is None else [{"action_id": last_bet, "player": names[-1]}]
+        return {"cp_nickname": names[0],
+                "rules": {"deck_size": deck, "jokers": 0, "blanks": 0,
+                          "common_cards": 0, "max_rounds": 8},
+                "players": players, "hands": hands, "common_hand": [],
+                "history": hist, "round_number": 1, "game_uuid": "t"}
+
+    def _assert_legal(self, action, deck, last_bet):
+        check = GameRules(deck).check_action_id
+        self.assertTrue(0 <= action <= check)
+        if last_bet is not None:
+            self.assertTrue(action == check or action > last_bet)
+
+    def test_unknown_personality_equals_baseline(self):
+        s = self._state(personality=None)
+        base = self.agent.determine_action(s)
+        s2 = self._state(personality="not_a_real_god")
+        self.assertEqual(self.agent.determine_action(s2), base)
+
+    def test_all_personalities_return_legal_actions(self):
+        for deck in (24, 32):
+            for name in P.PERSONALITY_NAMES:
+                s = self._state(deck=deck, n=2, k=2, last_bet=3, personality=name)
+                a = self.agent.determine_action(s)
+                self._assert_legal(a, deck, 3)
+
+    def test_delegated_domovoi_is_legal(self):
+        s = self._state(deck=24, n=4, k=1, last_bet=2, personality="domovoi")
+        a = self.agent.determine_action(s)
+        self._assert_legal(a, 24, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/personality_probe.py
+++ b/tools/personality_probe.py
@@ -1,0 +1,254 @@
+"""Behavioral probe for the Blef personality layer.
+
+Runs every personality (and the unmodified baseline policy) over many realistic
+game states and measures the *signature* of the moves they choose, so we can
+verify each bot plays the way it was designed to — and tune the knobs against
+real numbers rather than vibes.
+
+Metrics per personality (deltas are vs the baseline policy on the SAME states):
+  check%   how often it challenges (only over states where check is legal)
+  pPriv    mean P(chosen bet is true | my hand)  — LOW => bluffy, HIGH => honest
+  div      mean (pPriv - pub) of chosen bet      — HIGH => leaky/readable
+  rank     mean position of the bet in the legal range — HIGH => big senior leaps
+  rankStd  spread of rank                        — HIGH => chaotic/unpredictable
+
+Usage:
+  venv_nfsp/bin/python tools/personality_probe.py            # full report
+  venv_nfsp/bin/python tools/personality_probe.py --n 600    # more states
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import statistics as st
+from collections import defaultdict
+
+import numpy as np
+import torch
+
+import warnings
+warnings.filterwarnings("ignore")
+
+from nfsp_ai import production_agent as pa
+from nfsp_ai import personalities as P
+from shared.game_utils import GameRules
+from shared.probabilities.dynamic_probabilities import (
+    get_bet_probabilities,
+    get_generic_bet_probabilities,
+)
+
+AGENT = pa.load_agent()
+
+
+# --------------------------------------------------------------------------- #
+# State generation
+# --------------------------------------------------------------------------- #
+def _deal(deck, sizes, rng):
+    vals = 6 if deck == 24 else 8
+    cards = [(v, c) for v in range(vals) for c in range(4)]
+    rng.shuffle(cards)
+    out, i = [], 0
+    for k in sizes:
+        out.append(cards[i:i + k])
+        i += k
+    return out
+
+
+def build_state(rng, *, deck=24, kcards=None, n=2, round_number=None,
+                last_bet="auto", team=False):
+    """Build a valid game-state dict (+ its check_action_id)."""
+    gr = GameRules(deck)
+    check = gr.check_action_id
+    if kcards is None:
+        kcards = [rng.randint(1, 3) for _ in range(n)]
+    n = len(kcards)
+    hands_cards = _deal(deck, kcards, rng)
+    names = [f"p{i}" for i in range(n)]
+    teams = [None] * n
+    if team and n >= 2:
+        teams = [1 if i % 2 == 0 else 2 for i in range(n)]
+    players = [{"nickname": names[i], "n_cards": kcards[i], "team": teams[i]} for i in range(n)]
+    hands = [{"nickname": names[i],
+              "hand": [{"value": v, "colour": c} for (v, c) in hands_cards[i]]}
+             for i in range(n)]
+    if last_bet == "auto":
+        last_bet = rng.randint(0, check - 2) if rng.random() < 0.75 else None
+    hist = [] if last_bet is None else [{"action_id": int(last_bet), "player": names[-1]}]
+    if round_number is None:
+        round_number = rng.randint(1, 6)
+    state = {
+        "cp_nickname": names[0],
+        "rules": {"deck_size": deck, "jokers": 0, "blanks": 0,
+                  "common_cards": 0, "max_rounds": 8},
+        "players": players,
+        "hands": hands,
+        "common_hand": [],
+        "history": hist,
+        "round_number": round_number,
+        "game_uuid": "probe",
+    }
+    return state, check
+
+
+def state_probs(state):
+    last = state["history"][-1]["action_id"] if state["history"] else -1
+    pvt = get_bet_probabilities(game_state=state, for_betting=True, last_bet=last)
+    pub = get_generic_bet_probabilities(game_state=state, last_bet=last)
+    return pvt, pub, last
+
+
+# --------------------------------------------------------------------------- #
+# Evaluation
+# --------------------------------------------------------------------------- #
+def eval_personality(states, name, repeats=1):
+    """name=None => baseline. repeats>1 averages stochastic gods."""
+    checks = 0
+    checkable = 0
+    pprivs, divs, ranks = [], [], []
+    for (state, check, pvt, pub, last) in states:
+        is_checkable = bool(state["history"])
+        checkable += int(is_checkable)
+        lo = (last + 1) if last >= 0 else 0
+        hi = check - 1
+        rng_span = max(1, hi - lo)
+        for _ in range(repeats):
+            probe = dict(state)
+            probe["personality"] = name
+            a = AGENT.determine_action(probe)
+            if a == check:
+                checks += 1
+                continue
+            if a < check:
+                ranks.append((a - lo) / rng_span)
+                pprivs.append(float(pvt[a]))
+                divs.append(float(pvt[a] - pub[a]))
+    n_check_obs = max(1, checkable * repeats)
+    return {
+        "check": checks / n_check_obs,
+        "pPriv": st.fmean(pprivs) if pprivs else float("nan"),
+        "div": st.fmean(divs) if divs else float("nan"),
+        "rank": st.fmean(ranks) if ranks else float("nan"),
+        "rankStd": st.pstdev(ranks) if len(ranks) > 1 else 0.0,
+        "n_bet": len(pprivs),
+    }
+
+
+def interpret(name, base, m):
+    """Auto-generate a one-line read of how this god deviates from baseline."""
+    bits = []
+    dchk = (m["check"] - base["check"]) * 100
+    if abs(dchk) >= 4:
+        bits.append(f"{'challenges more' if dchk > 0 else 'rarely checks'} ({dchk:+.0f}pp)")
+    dpp = m["pPriv"] - base["pPriv"]
+    if abs(dpp) >= 0.02:
+        bits.append(f"{'bluffier' if dpp < 0 else 'more honest'} ({dpp:+.3f} pPriv)")
+    ddiv = m["div"] - base["div"]
+    if abs(ddiv) >= 0.02:
+        bits.append(f"{'leakier/readable' if ddiv > 0 else 'more concealed'} ({ddiv:+.3f} div)")
+    drank = m["rank"] - base["rank"]
+    if abs(drank) >= 0.03:
+        bits.append(f"{'bigger leaps' if drank > 0 else 'min increments'} ({drank:+.3f} rank)")
+    drs = m["rankStd"] - base["rankStd"]
+    if drs >= 0.04:
+        bits.append(f"more chaotic ({drs:+.3f} rankStd)")
+    return "; ".join(bits) if bits else "~ baseline"
+
+
+def table(title, states, names, repeats_for):
+    base = eval_personality(states, None)
+    print(f"\n=== {title}  (states={len(states)}, baseline "
+          f"check={base['check']*100:.0f}% pPriv={base['pPriv']:.3f} "
+          f"div={base['div']:.3f} rank={base['rank']:.3f} rankStd={base['rankStd']:.3f}) ===")
+    print(f"{'god':12s} {'src':6s} {'dChk':>6s} {'dpPriv':>8s} {'ddiv':>8s} "
+          f"{'drank':>7s} {'rankStd':>8s}   interpretation")
+    rows = {}
+    for name in names:
+        cfg = P.PERSONALITIES[name]
+        if P.is_delegated(name):
+            m = eval_personality(states, name)
+            rows[name] = m
+            print(f"{name:12s} {cfg.source[:6]:6s} {'(delegated heuristic engine)':>40s}")
+            continue
+        m = eval_personality(states, name, repeats=repeats_for.get(name, 1))
+        rows[name] = m
+        print(f"{name:12s} {cfg.source[:6]:6s} "
+              f"{(m['check']-base['check'])*100:+6.0f} {m['pPriv']-base['pPriv']:+8.3f} "
+              f"{m['div']-base['div']:+8.3f} {m['rank']-base['rank']:+7.3f} "
+              f"{m['rankStd']:8.3f}   {interpret(name, base, m)}")
+    return base, rows
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=500)
+    ap.add_argument("--seed", type=int, default=7)
+    args = ap.parse_args()
+    rng = random.Random(args.seed)
+    torch.manual_seed(args.seed)
+
+    # Stochastic gods (chaos>0) get repeats so their averages are stable.
+    repeats_for = {n: 4 for n, c in P.PERSONALITIES.items()
+                   if c.chaos > 0.05 or c.mood in ("random_chaos", "spike_random", "win_ramp")}
+
+    def make(nstates, **kw):
+        out = []
+        for _ in range(nstates):
+            s, chk = build_state(rng, **kw)
+            pvt, pub, last = state_probs(s)
+            out.append((s, chk, pvt, pub, last))
+        return out
+
+    names = P.PERSONALITY_NAMES
+
+    # Main 1v1 / 24 mixed-depth table
+    main_states = make(args.n, deck=24, n=2)
+    table("1v1 deck-24 (mixed depth)", main_states, names, repeats_for)
+
+    # Multi-player / 24
+    multi_states = make(args.n // 2, deck=24, n=4)
+    table("4-player deck-24 (mixed depth)", multi_states, names, repeats_for)
+
+    # Deck 32
+    d32 = make(args.n // 2, deck=32, n=2)
+    table("1v1 deck-32 (mixed depth)", d32, names, repeats_for)
+
+    # --- Mood cohorts: early vs late (depth) for phase gods --------------- #
+    phase_gods = ["triglav", "veles", "poludnica", "mokosh", "rusalka", "porevit"]
+    early = make(args.n // 2, deck=24, n=2, kcards=[1, 1], round_number=1)
+    late = make(args.n // 2, deck=24, n=2, kcards=[5, 5], round_number=6)
+    print("\n\n########## MOOD: EARLY (round1, 1 card) vs LATE (round6, 5 cards) ##########")
+    be, re_ = table("PHASE early", early, phase_gods, repeats_for)
+    bl, rl = table("PHASE late", late, phase_gods, repeats_for)
+    print("\n-- phase deltas (late - early) for phase gods --")
+    for g in phase_gods:
+        print(f"  {g:10s} d_pPriv={rl[g]['pPriv']-re_[g]['pPriv']:+.3f}  "
+              f"d_rank={rl[g]['rank']-re_[g]['rank']:+.3f}  "
+              f"d_chk={(rl[g]['check']-re_[g]['check'])*100:+.0f}pp  "
+              f"d_rankStd={rl[g]['rankStd']-re_[g]['rankStd']:+.3f}")
+
+    # --- Mood cohorts: ahead vs behind (standing) for standing gods ------- #
+    stand_gods = ["perun", "kupala", "dazhbog"]
+    ahead = make(args.n // 2, deck=24, kcards=[1, 4], round_number=4)   # cp has fewer => winning
+    behind = make(args.n // 2, deck=24, kcards=[4, 1], round_number=4)  # cp has more => losing
+    print("\n\n########## MOOD: AHEAD (cp 1 vs 4) vs BEHIND (cp 4 vs 1) ##########")
+    ba, ra = table("STANDING ahead", ahead, stand_gods, repeats_for)
+    bb, rb = table("STANDING behind", behind, stand_gods, repeats_for)
+    print("\n-- standing deltas (ahead - behind) --")
+    for g in stand_gods:
+        print(f"  {g:10s} d_pPriv={ra[g]['pPriv']-rb[g]['pPriv']:+.3f}  "
+              f"d_rank={ra[g]['rank']-rb[g]['rank']:+.3f}  "
+              f"d_chk={(ra[g]['check']-rb[g]['check'])*100:+.0f}pp")
+
+    # --- Zorya parity: even vs odd round ---------------------------------- #
+    print("\n\n########## MOOD: ZORYA parity (even vs odd round) ##########")
+    even = make(args.n // 2, deck=24, n=2, round_number=2)
+    odd = make(args.n // 2, deck=24, n=2, round_number=3)
+    be2, re2 = table("ZORYA even-round (dawn)", even, ["zorya"], repeats_for)
+    bo2, ro2 = table("ZORYA odd-round (dusk)", odd, ["zorya"], repeats_for)
+    print(f"  zorya dawn-dusk d_chk={(re2['zorya']['check']-ro2['zorya']['check'])*100:+.0f}pp "
+          f"d_pPriv={re2['zorya']['pPriv']-ro2['zorya']['pPriv']:+.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/personality_winrate.py
+++ b/tools/personality_winrate.py
@@ -1,0 +1,108 @@
+"""Head-to-head win-rate of each personality vs the standard NFSP baseline.
+
+Plays full Blef games using the SAME orchestration as NFSP self-play training
+(`shared.api.simpleschema_local_manager`: create_game + play), driving each seat
+with `production_agent.determine_action`. The opponent is the unmodified policy
+(no personality => the standard variant-routed NFSP model). Seats are alternated
+to remove first-move bias.
+
+A "playable" personality should be WEAKER than the baseline (it deviates from
+near-equilibrium, so it is exploitable) but must stay competitive — not lose
+almost every game. Use this to bound tempo/chaos/risk so bots remain fun, not
+free wins.
+
+Usage:
+  venv_nfsp/bin/python tools/personality_winrate.py --games 200
+  venv_nfsp/bin/python tools/personality_winrate.py --games 400 --deck 24 --only perun,czernobog
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import warnings
+
+warnings.filterwarnings("ignore")
+
+import torch
+
+from nfsp_ai import production_agent as pa
+from nfsp_ai import personalities as P
+import shared.api.simpleschema_local_manager as gm
+
+AGENT = pa.load_agent()
+
+
+def play_game(pers0, pers1, *, deck=24, max_cards=11, max_moves=4000):
+    """One full 1v1 game. Returns winning seat ('0'/'1') or None on timeout."""
+    game = gm.create_game(2, deck_size=deck, max_cards=max_cards,
+                          jokers=0, blanks=0, common_cards=0)
+    pmap = {"0": pers0, "1": pers1}
+    for pl in game["players"]:
+        pl["personality"] = pmap[pl["nickname"]]
+    moves = 0
+    while game.get("status") != "Finished" and moves < max_moves:
+        if game.get("cp_nickname") is None:
+            break
+        action = AGENT.determine_action(game)
+        gm.play(game, int(action))
+        # gm.play strips/re-deals players; re-stamp personality each round.
+        for pl in game["players"]:
+            pl["personality"] = pmap.get(pl["nickname"])
+        moves += 1
+    active = [p for p in game["players"] if p["n_cards"] > 0]
+    return active[0]["nickname"] if len(active) == 1 else None
+
+
+def winrate(name, games, *, deck=24):
+    wins = decided = 0
+    for i in range(games):
+        if i % 2 == 0:
+            w = play_game(name, None, deck=deck)
+            me = "0"
+        else:
+            w = play_game(None, name, deck=deck)
+            me = "1"
+        if w is None:
+            continue
+        decided += 1
+        wins += int(w == me)
+    return (wins / decided if decided else float("nan")), decided
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--games", type=int, default=200)
+    ap.add_argument("--deck", type=int, default=24)
+    ap.add_argument("--seed", type=int, default=11)
+    ap.add_argument("--only", type=str, default="")
+    args = ap.parse_args()
+    random.seed(args.seed)
+    torch.manual_seed(args.seed)
+
+    names = P.PERSONALITY_NAMES
+    if args.only:
+        names = [n.strip() for n in args.only.split(",") if n.strip()]
+
+    # Calibration: baseline vs baseline should sit near 50%.
+    bb, bd = winrate(None, args.games, deck=args.deck)
+    print(f"\n=== win-rate vs standard NFSP baseline (deck {args.deck}, "
+          f"{args.games} games/seat-balanced) ===")
+    print(f"{'(baseline vs baseline)':16s}  win%={bb*100:5.1f}  decided={bd}/{args.games}")
+    print(f"{'god':16s}  {'win%':>6s}  {'decided':>8s}   note")
+    rows = []
+    for n in names:
+        wr, dec = winrate(n, args.games, deck=args.deck)
+        rows.append((n, wr, dec))
+        flag = ""
+        if wr < 0.12:
+            flag = "  <-- TOO WEAK (loses almost always)"
+        elif wr > 0.55:
+            flag = "  <-- stronger than baseline?"
+        print(f"{n:16s}  {wr*100:5.1f}  {dec:6d}/{args.games}{flag}")
+    print("\nTarget: roughly 20-45% (weaker but competitive). "
+          "Wall gods (perun) may approach ~50%.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Turns the single SOTA NFSP policy into **16 distinct, named opponents** — each with a
different difficulty and recognizable quirks — without retraining, without new ECR images,
and without changing the orchestrator. A personality is **data**, selected per move.

- **One image, one function.** All NFSP deities are served by the existing `blef-aiagent-nfsp`
  container. The personality is resolved inside the lambda from the current player's nickname
  (`perun_(AI)` → `perun`) or an explicit `personality` field. Unknown/absent → **exact current
  baseline** (existing AI players unaffected). Morana stays on `blef-aiagent-cfr`.
- **How a style is made:** choice of NFSP head (`pi` average-policy vs `q` best-response)
  + a *bounded* log-probability overlay over the two probability vectors the agent already
  computes, + in-distribution top-k "chaos", + a stateless per-move mood.
  - `risk` — honesty↔bluff on `p_priv(a)=P(set exists | my hand)`
  - `guard` — concealment↔readability on the `p_priv−pub` divergence (betting your private
    truth leaks your hand; the rules README names this tension)
  - `susp` — check threshold on `p_priv(last)`
  - `tempo` — betting cadence (the only index-based knob; never a truth proxy)
  - `chaos` — top-k sampling over the *sculpted* policy (NOT temperature — the NFSP policy is
    so peaked that any temperature collapses it toward random)
  - mood — depth/standing/round-parity derived from the per-move state (no cross-game memory)
- **Domovoi** delegates to the existing `conservative_crawling` heuristic (now bundled in the
  image) for a genuinely different, low-variance feel.

## Validation (vs the standard 1v1 NFSP baseline)

Full self-play games via the training manager (`tools/personality_winrate.py`) + move-signature
probes (`tools/personality_probe.py`). Baseline-vs-baseline calibrates at 46.9%. Heuristic floor:
`conservative_ai` 20.0%, `conservative_crawling` 22.5%.

| tier | win% vs baseline |
|---|---|
| wall/strong | perun 51, svetovid 52, dazhbog 52, mokosh 50, triglav 49, porevit 48, zorya 46, kupala 44 |
| mid | mavka 32, rusalka 30 |
| loud/easy | czernobog 28, veles 28, poludnica 26, leshy 24, domovoi 22, baba_yaga 22 |

Every god is weaker-but-competitive (20–52%): none a free win, none constantly losing (tempo/chaos
bounded). 15 unit/smoke tests pass (`tests/test_personalities.py`), incl. all 16 personalities
returning legal actions on deck 24/32 and `unknown personality == baseline`.

## Deployed to production (eu-west-2, account 195324961675)

- Image **`blef-nfsp-lambda:personalities-v1`** (digest `583ccef…`) pushed; `blef-aiagent-nfsp`
  swapped to it (State Active / Successful). Verified with two live invokes (Leshy + Domovoi → 200).
- `blef-invite-aiagent` `agent_mapping`/`AGENT_MAPPING` merged: all 16 deities → `nfsp`,
  `Morana`→`cfr`; **Dazhbog/Porevit moved from the heuristic engines to their NFSP personalities**;
  test entries (`Checkbog`, `TestMorana`) preserved; nothing removed.

### Rollback runbook
```
# 1) Revert the AI image (previous live tag is untouched):
aws lambda update-function-code --function-name blef-aiagent-nfsp --region eu-west-2 \
  --image-uri 195324961675.dkr.ecr.eu-west-2.amazonaws.com/blef-nfsp-lambda:lambda-compatible
#    (exact prior digest: sha256:cd3670f383b37788ee7f9511cc20a6a9782f40793a76f17963a9a8f2ba40361f)

# 2) Revert the engine env (previous agent_mapping):
#    Dazhbog->conservative, Porevit->conservative-crawling, Perun->nfsp, Morana->cfr,
#    Checkbog->test-checker, TestMorana->cfr-container   (no deity entries)
aws lambda update-function-configuration --function-name blef-invite-aiagent --region eu-west-2 \
  --environment '{"Variables":{"agent_mapping":"{\"Dazhbog\":\"conservative\",\"Checkbog\":\"test-checker\",\"Porevit\":\"conservative-crawling\",\"Morana\":\"cfr\",\"Perun\":\"nfsp\",\"TestMorana\":\"cfr-container\"}","AGENT_MAPPING":"{\"Dazhbog\":\"conservative\",\"Checkbog\":\"test-checker\",\"Porevit\":\"conservative-crawling\",\"Morana\":\"cfr\",\"Perun\":\"nfsp\",\"TestMorana\":\"cfr-container\"}"}}'
```

## Note for review
- **Perun behavior changed**: previously the `perun` name was plain baseline NFSP; it is now the
  Perun personality (q-head + light tint, ~51% vs baseline — still the wall, but moves differ).
  Say the word if you'd rather keep `perun` as plain baseline and name the warlord differently.
- The `agent_mapping` keys must match the personality ids case-insensitively (e.g. `Baba_Yaga`,
  not `BabaYaga`) so the nickname prefix-match resolves.

## Test plan
- [x] `python -m unittest tests.test_personalities` (15 pass)
- [x] `tools/personality_winrate.py` — win-rates in 20–52% band
- [x] `tools/personality_probe.py` — move signatures match design intent
- [x] live invoke of `blef-aiagent-nfsp` (Leshy, Domovoi) → 200
- [ ] play a real game per deity through the engine and eyeball feel

🤖 Generated with [Claude Code](https://claude.com/claude-code)