### PR TITLE
production_agent: filter mask by public-priors at inference

### DIFF
--- a/nfsp_ai/agent.py
+++ b/nfsp_ai/agent.py
@@ -1172,6 +1172,7 @@ class NFSPAgent:
         loser=None,          # <-- loser id ONLY on terminal step (None otherwise)
         actor_team=None,     # <-- actor's team id (None in solo mode); per-step
         loser_team=None,     # <-- loser's team id (None in solo mode); terminal-only
+        personality_terminal_scale: float = 1.0,  # multiplied into the MC terminal credit; 1.0 = no shaping
     ):
         if not hasattr(self, "_nstep_queue"):
             raise ValueError("_nstep_queue not in self!")
@@ -1220,6 +1221,10 @@ class NFSPAgent:
             "loser": loser if done else None, # ONLY present on terminal step
             "actor_team": actor_team,        # team id for THIS step's actor (None in solo)
             "loser_team": loser_team if done else None,  # team id of the round's loser
+            # Per-trajectory personality terminal-magnitude scalar; only the
+            # terminal entry's value is read in _flush_nstep. Default 1.0 (no
+            # shaping) for the baseline pantheon and non-terminal steps.
+            "personality_terminal_scale": float(personality_terminal_scale) if done else 1.0,
         }
         self._nstep_queue.append(entry)
 
@@ -1305,7 +1310,10 @@ class NFSPAgent:
                 sign = -1.0 if actor_team == loser_team else +1.0
             else:
                 sign = -1.0 if actor_id == loser_id else +1.0
-            R = sign * g
+            # Personality terminal-magnitude shaping: multiply the MC credit by
+            # the scalar emitted at terminal by the env (1.0 = no shaping).
+            ps_scale = float(term.get("personality_terminal_scale", 1.0))
+            R = sign * g * ps_scale
 
             if not step.get("is_br", False):
                 continue
@@ -1535,6 +1543,7 @@ class NFSPAgent:
             if rr is not None:
                 loser = rr.get("loser", None)
                 loser_team = rr.get("loser_team", None)
+            ps_scale = float(info_dict.get("personality_terminal_scale", 1.0)) if info_dict else 1.0
 
             # Pass actor/loser (and their teams) so _flush_nstep can
             # distribute rewards correctly in both solo and team modes.
@@ -1547,6 +1556,7 @@ class NFSPAgent:
                     obs, mask, action, reward, nobs, nmask, done, is_br=use_br,
                     actor=actor, loser=loser,
                     actor_team=actor_team, loser_team=loser_team,
+                    personality_terminal_scale=ps_scale,
                 )
 
             # Ensure n-step buffer flushes at terminals (round end)
@@ -1943,29 +1953,44 @@ class NFSPAgent:
             "check_explore_prob": float(getattr(self, "_check_explore_prob", 0.0)),
         }, path)
 
-    def export_inference(self, path: str, *, team_aware: Optional[bool] = None):
+    def export_inference(
+        self,
+        path: str,
+        *,
+        team_aware: Optional[bool] = None,
+        personality_spec_dict: Optional[dict] = None,
+    ):
         """Persist an inference-only checkpoint.
 
         `team_aware` records whether the model's expected obs vector
         includes the per-slot team-flag block. Stamped in cfg so the
         production loader doesn't have to probe obs_dim. Defaults to
         True (current training-time obs format) when not specified.
+
+        `personality_spec_dict` (when set) is the serialised
+        ``PersonalityTrainSpec`` the run was trained with. Stamped in
+        cfg["personality"] so the production loader reapplies the obs
+        blind-spots and mask restrictions at serve time (symmetric to
+        training). Version bumps to 3 when present.
         """
+        cfg: dict = {
+            "hidden": int(self.cfg.hidden),
+            "factorize_action_head": bool(getattr(self.cfg, "factorize_action_head", False)),
+            "team_aware": bool(team_aware) if team_aware is not None else True,
+            "gamma": float(self.cfg.gamma),
+            "anticipatory_eta": float(self.cfg.anticipatory_eta),
+            "eps_start": float(self.cfg.eps_start),
+            "eps_end": float(self.cfg.eps_end),
+        }
+        if personality_spec_dict is not None:
+            cfg["personality"] = personality_spec_dict
         payload = {
-            "version": 2,
+            "version": 3 if personality_spec_dict is not None else 2,
             "obs_dim": int(self.obs_dim),
             "act_dim": int(self.act_dim),
             "q": self.q.state_dict(),
             "pi": self.pi.state_dict(),
-            "cfg": {
-                "hidden": int(self.cfg.hidden),
-                "factorize_action_head": bool(getattr(self.cfg, "factorize_action_head", False)),
-                "team_aware": bool(team_aware) if team_aware is not None else True,
-                "gamma": float(self.cfg.gamma),
-                "anticipatory_eta": float(self.cfg.anticipatory_eta),
-                "eps_start": float(self.cfg.eps_start),
-                "eps_end": float(self.cfg.eps_end),
-            },
+            "cfg": cfg,
         }
         torch.save(payload, path)
 

--- a/nfsp_ai/nfsp_run_local.py
+++ b/nfsp_ai/nfsp_run_local.py
@@ -41,11 +41,12 @@ class DeckSpec:
     use_card_embeddings: bool
     use_history_embeddings: bool
     # When True, vectorize_obs appends MAX_PLAYERS extra floats encoding
-    # per-slot team membership (+1 teammate / -1 opp / 0 none). Default
-    # True for new trainings; production_agent flips it to False when
-    # loading legacy checkpoints whose obs_dim predates the team-flag
-    # block (so old artifacts keep working post-deploy).
-    team_aware: bool = True
+    # per-slot team membership (+1 teammate / -1 opp / 0 none). Defaults
+    # False so the obs schema stays backward-compatible with pre-team
+    # checkpoints (whose obs_dim predates the team-flag block); MyEnv turns
+    # it on automatically whenever team mode is active (n_teams >= 2), and
+    # callers can force it on via the flag.
+    team_aware: bool = False
 
 
 def _compute_obs_dim(
@@ -53,7 +54,7 @@ def _compute_obs_dim(
     hist_dim: int,
     card_feature_dim: Optional[int] = None,
     history_feature_dim: Optional[int] = None,
-    team_aware: bool = True,
+    team_aware: bool = False,
 ) -> int:
     card_dim = card_feature_dim if card_feature_dim is not None else hand_vec_dim
     history_dim = history_feature_dim if history_feature_dim is not None else hist_dim
@@ -78,7 +79,7 @@ def _build_deck_spec(
     rules: Dict,
     card_embedding: Optional["CardEmbeddingRuntime"] = None,
     history_embedding: Optional["HistoryEmbeddingRuntime"] = None,
-    team_aware: bool = True,
+    team_aware: bool = False,
 ) -> DeckSpec:
     deck_size = int(rules.get("deck_size", 24))
     if deck_size % 4 != 0:
@@ -208,7 +209,7 @@ def _deck_spec_from_game(
     game: dict,
     card_embedding: Optional["CardEmbeddingRuntime"] = None,
     history_embedding: Optional["HistoryEmbeddingRuntime"] = None,
-    team_aware: bool = True,
+    team_aware: bool = False,
 ) -> DeckSpec:
     rules = game.get("rules", {}) or {}
     return _build_deck_spec(
@@ -754,7 +755,7 @@ def vectorize_obs(
     # opponent, 0 if no player in slot or game is solo (no team mode).
     # Gated on spec.team_aware so legacy checkpoints (obs_dim predates
     # the team-flag block) keep producing the original obs shape.
-    if getattr(spec, "team_aware", True):
+    if getattr(spec, "team_aware", False):
         team_map = {p.get("nickname"): p.get("team") for p in players}
         actor_team = team_map.get(game.get("cp_nickname"))
         team_flags = np.zeros((MAX_PLAYERS,), dtype=np.float32)
@@ -894,7 +895,7 @@ class MyEnv:
         pick_n_teams_in_range: bool = False,
         n_teams: int = 0,
         randomize_initial_hands: bool = False,
-        team_aware: bool = True,
+        team_aware: bool = False,
         personality_spec=None,
     ):
         if n_agents < 2 or n_agents > 8:
@@ -908,7 +909,10 @@ class MyEnv:
         self.blank_cap = max(0, int(blanks))
         self.common_card_cap = max(0, int(common_cards))
         self.n_teams_cap = max(0, int(n_teams))
-        self.team_aware = bool(team_aware)
+        # Auto-enable the team-flag obs block whenever team mode is active,
+        # even if the caller left team_aware at its backward-compatible
+        # False default. An explicit team_aware=True still forces it on.
+        self.team_aware = bool(team_aware) or self.n_teams_cap >= 2
         # Optional personality bias spec (PersonalityTrainSpec). Attached to
         # deck_spec on every rebuild so vectorize_obs and _legal_action_mask
         # can find it via the spec they already receive. None = baseline.
@@ -1906,7 +1910,7 @@ def main():
         )
         agent.export_inference(
             export_path,
-            team_aware=bool(getattr(env.deck_spec, "team_aware", True)),
+            team_aware=bool(getattr(env.deck_spec, "team_aware", False)),
             personality_spec_dict=personality_dict,
         )
         print(f"[export] inference-only checkpoint saved to {export_path}")

--- a/nfsp_ai/nfsp_run_local.py
+++ b/nfsp_ai/nfsp_run_local.py
@@ -510,6 +510,14 @@ def _legal_action_mask(game: dict, spec: DeckSpec, pub_prior: list) -> torch.Ten
             # walks into this corner.
             if not mask.any() and check_legal_pre:
                 mask[check] = 1.0
+
+    # Per-personality hard-mask restrictions, with their own safety rail
+    # (mandatory: never produce an empty mask). No-op when spec carries no
+    # personality_spec attribute (the baseline pantheon / untrained personalities).
+    psspec = getattr(spec, "personality_spec", None)
+    if psspec is not None:
+        from nfsp_ai.personality_train import apply_personality_to_mask
+        mask = apply_personality_to_mask(mask, psspec, spec)
     return torch.from_numpy(mask)
 
 
@@ -820,6 +828,14 @@ def vectorize_obs(
     if idx != spec.obs_dim:
         raise ValueError(f"vectorize_obs produced dim {idx}, expected {spec.obs_dim}")
 
+    # Per-personality obs zero-mask (perceptual blind spots). No-op when no
+    # personality_spec is attached. Applied AFTER the dim check so the layout
+    # resolver and _compute_obs_dim stay the single source of truth.
+    psspec = getattr(spec, "personality_spec", None)
+    if psspec is not None:
+        from nfsp_ai.personality_train import apply_personality_to_obs
+        apply_personality_to_obs(obs, psspec, spec)
+
     # Validations on probability slices
     if len(pvt_prior) != spec.hist_dim:
         raise ValueError(
@@ -879,6 +895,7 @@ class MyEnv:
         n_teams: int = 0,
         randomize_initial_hands: bool = False,
         team_aware: bool = True,
+        personality_spec=None,
     ):
         if n_agents < 2 or n_agents > 8:
             raise ValueError("n_agents must be in [2, 8]")
@@ -892,6 +909,10 @@ class MyEnv:
         self.common_card_cap = max(0, int(common_cards))
         self.n_teams_cap = max(0, int(n_teams))
         self.team_aware = bool(team_aware)
+        # Optional personality bias spec (PersonalityTrainSpec). Attached to
+        # deck_spec on every rebuild so vectorize_obs and _legal_action_mask
+        # can find it via the spec they already receive. None = baseline.
+        self.personality_spec = personality_spec
         self.rules = {
             "deck_size": int(deck_size),
             "jokers": self.joker_cap,
@@ -907,6 +928,7 @@ class MyEnv:
             history_embedding=self.history_embedding,
             team_aware=self.team_aware,
         )
+        self.deck_spec.personality_spec = self.personality_spec
 
         self.verbose = verbose
         self.illegal_penalty = float(illegal_penalty)
@@ -958,6 +980,7 @@ class MyEnv:
                 history_embedding=self.history_embedding,
                 team_aware=self.team_aware,
             )
+            self.deck_spec.personality_spec = self.personality_spec
             cp = self.game.get("cp_nickname")
             obs, pub_prior = vectorize_obs(
                 self.game,
@@ -1032,6 +1055,7 @@ class MyEnv:
             history_embedding=self.history_embedding,
             team_aware=self.team_aware,
         )
+        self.deck_spec.personality_spec = self.personality_spec
 
         # New match bookkeeping
         self.rounds_since_reset = 0
@@ -1112,6 +1136,7 @@ class MyEnv:
             history_embedding=self.history_embedding,
             team_aware=self.team_aware,
         )
+        self.deck_spec.personality_spec = self.personality_spec
         cp = self.game.get("cp_nickname")
         obs, pub_prior = vectorize_obs(
             self.game,
@@ -1129,6 +1154,7 @@ class MyEnv:
         round_result = None
         history_for_log = None
         done_reason = None
+        personality_terminal_scale = 1.0
 
         if is_check:
             # Round has been resolved by the manager, and a new round likely started.
@@ -1179,6 +1205,21 @@ class MyEnv:
             }
             history_for_log = history_before
 
+            # Personality terminal-magnitude shaping. Uses history_before (the
+            # round's actions in order, captured before gm.play() advanced the
+            # state). compute_personality_terminal_scale returns 1.0 when no
+            # personality_spec is attached, so this is a no-op for the baseline.
+            psspec = getattr(self.deck_spec, "personality_spec", None)
+            if psspec is not None and loser is not None:
+                from nfsp_ai.personality_train import compute_personality_terminal_scale
+                personality_terminal_scale = compute_personality_terminal_scale(
+                    psspec,
+                    {"history": history_before},
+                    actor_nick,
+                    loser,
+                    int(self.deck_spec.deck_size),
+                )
+
             # --- Key change: make the round boundary terminal ---
             done = True
             done_reason = "round_terminal"
@@ -1226,6 +1267,9 @@ class MyEnv:
             "history": history_for_log,
             "round_result": round_result,
             "reward": float(reward),
+            # Per-trajectory shaping scalar; multiplied into the MC return in
+            # agent._flush_nstep. 1.0 means no shaping (baseline / non-terminal).
+            "personality_terminal_scale": float(personality_terminal_scale),
             # Helpful breadcrumbs for debugging:
             "round_terminal": bool(is_check),
             "game_status": self.game.get("status", ""),
@@ -1509,6 +1553,19 @@ def main():
         help="Optional path to save an inference-only checkpoint (no training buffers).",
     )
     parser.add_argument(
+        "--personality-spec",
+        dest="personality_spec_path",
+        type=str,
+        default=None,
+        help=(
+            "Optional path to a PersonalityTrainSpec JSON. When set, the env "
+            "applies the spec's obs blind-spots, mask restrictions, and "
+            "terminal-magnitude shaping during training; the export-inference "
+            "checkpoint is stamped with the spec so production reapplies the "
+            "obs/mask hooks at serve time. See nfsp_ai/personality_specs/."
+        ),
+    )
+    parser.add_argument(
         "--verbose",
         action="store_true",
         help="Enable verbose logging from the game manager.",
@@ -1738,6 +1795,12 @@ def main():
     else:
         print("[embeddings] using legacy history multi-hot features.")
 
+    personality_spec_obj = None
+    if getattr(args, "personality_spec_path", None):
+        from nfsp_ai.personality_train import load_spec
+        personality_spec_obj = load_spec(args.personality_spec_path)
+        print(f"[personality] loaded {personality_spec_obj.name!r} from {args.personality_spec_path}")
+
     env = MyEnv(
         n_agents=args.n_agents,
         max_cards=args.max_cards,
@@ -1759,6 +1822,7 @@ def main():
         n_teams=getattr(args, "n_teams", 0),
         pick_n_teams_in_range=getattr(args, "pick_n_teams_in_range", False),
         randomize_initial_hands=args.randomize_initial_hands,
+        personality_spec=personality_spec_obj,
     )
     obs0, mask0, _ = env.reset()
 
@@ -1823,6 +1887,7 @@ def main():
         pick_common_cards_in_range=args.pick_common_cards_in_range,
         n_teams=getattr(args, "n_teams", 0),
         pick_n_teams_in_range=getattr(args, "pick_n_teams_in_range", False),
+        personality_spec=personality_spec_obj,
         # Eval env intentionally does NOT use randomize_initial_hands: the RIC
         # curriculum is a training-time intervention; eval scores the agent on
         # natural-distribution starts (all players begin with 1 card).
@@ -1831,11 +1896,18 @@ def main():
     if args.export_inference:
         export_path = os.path.abspath(args.export_inference)
         os.makedirs(os.path.dirname(export_path) or ".", exist_ok=True)
-        # Stamp team_aware from the training env's deck spec so the
-        # production loader doesn't have to probe obs_dim.
+        # Stamp team_aware (from training env's deck spec) and personality
+        # (when the run was driven by --personality-spec) so the production
+        # loader doesn't have to probe obs_dim and can reapply the obs/mask
+        # hooks symmetrically at serve time.
+        from nfsp_ai.personality_train import spec_to_dict
+        personality_dict = (
+            spec_to_dict(personality_spec_obj) if personality_spec_obj is not None else None
+        )
         agent.export_inference(
             export_path,
             team_aware=bool(getattr(env.deck_spec, "team_aware", True)),
+            personality_spec_dict=personality_dict,
         )
         print(f"[export] inference-only checkpoint saved to {export_path}")
         return

--- a/nfsp_ai/personalities.py
+++ b/nfsp_ai/personalities.py
@@ -227,13 +227,15 @@ PERSONALITIES: dict[str, PersonalityConfig] = {
         note="Trickster. Per-move chaos swings between genius and nonsense; "
              "self-destructive randomness ('lost already?'). Easiest NFSP god.",
     ),
-    # --- Heuristic engine (no NFSP): genuinely different feel --------------- #
+    # --- Caretaker (TRAINED NFSP, replaces the conservative_crawling delegate) - #
     "domovoi": PersonalityConfig(
-        source="conservative_crawling",
-        note="Caretaker. Delegated to the conservative-crawling heuristic "
-             "(safe, plausible, team-aware, low-variance). Appears harmless "
-             "and is too readable for strong players ('a quiet house hides "
-             "many things').",
+        source="pi",
+        note="Caretaker. Trained NFSP biased toward loss-aversion + honest "
+             "simple claims (high card, pair, two pairs) + bluff-call bonus. "
+             "Replaces the previous conservative_crawling delegate. The "
+             "sculpt knobs are zero (no overlay); the trained-personality "
+             "checkpoint (artifacts/nfsp_inference_24_1v1_domovoi.pt) drives "
+             "the behavior. 'A quiet house hides many things.'",
     ),
 }
 

--- a/nfsp_ai/personality_specs/baba_yaga.json
+++ b/nfsp_ai/personality_specs/baba_yaga.json
@@ -1,0 +1,8 @@
+{
+  "name": "baba_yaga",
+  "loss_multiplier": 0.8,
+  "bluff_call_bonus": 0.6,
+  "hand_type_bias": {"Three of a kind": 0.3, "Four of a kind": 0.3},
+  "greedy": false,
+  "head": "pi"
+}

--- a/nfsp_ai/personality_specs/czernobog.json
+++ b/nfsp_ai/personality_specs/czernobog.json
@@ -1,0 +1,9 @@
+{
+  "name": "czernobog",
+  "win_multiplier": 1.5,
+  "loss_multiplier": 0.6,
+  "bluff_caught_penalty": -0.2,
+  "hand_type_bias": {"Straight flush": 0.4, "Four of a kind": 0.4},
+  "greedy": false,
+  "head": "pi"
+}

--- a/nfsp_ai/personality_specs/domovoi.json
+++ b/nfsp_ai/personality_specs/domovoi.json
@@ -1,0 +1,9 @@
+{
+  "name": "domovoi",
+  "loss_multiplier": 1.5,
+  "bluff_caught_penalty": 0.6,
+  "bluff_call_bonus": 0.3,
+  "hand_type_bias": {"High card": 0.1, "Pair": 0.15, "Two pairs": 0.1},
+  "greedy": false,
+  "head": "pi"
+}

--- a/nfsp_ai/personality_specs/kupala.json
+++ b/nfsp_ai/personality_specs/kupala.json
@@ -1,9 +1,8 @@
 {
   "name": "kupala",
-  "win_multiplier": 1.4,
-  "loss_multiplier": 0.7,
-  "bluff_call_bonus": 0.4,
-  "hand_type_bias": {"Three of a kind": 0.2, "Full house": 0.3},
+  "hand_type_bias": {"High card": -0.1, "Pair": -0.2, "Two pairs": -0.15},
+  "bluff_call_bonus": 0.3,
+  "bluff_caught_penalty": 0.3,
   "greedy": false,
   "head": "pi"
 }

--- a/nfsp_ai/personality_specs/kupala.json
+++ b/nfsp_ai/personality_specs/kupala.json
@@ -1,6 +1,6 @@
 {
   "name": "kupala",
-  "win_multiplier": 1.8,
-  "loss_multiplier": 0.5,
-  "forbid_check_unless_only": true
+  "forbid_check_unless_only": true,
+  "greedy": false,
+  "head": "pi"
 }

--- a/nfsp_ai/personality_specs/kupala.json
+++ b/nfsp_ai/personality_specs/kupala.json
@@ -1,0 +1,6 @@
+{
+  "name": "kupala",
+  "win_multiplier": 1.8,
+  "loss_multiplier": 0.5,
+  "forbid_check_unless_only": true
+}

--- a/nfsp_ai/personality_specs/kupala.json
+++ b/nfsp_ai/personality_specs/kupala.json
@@ -1,6 +1,9 @@
 {
   "name": "kupala",
-  "forbid_check_unless_only": true,
+  "win_multiplier": 1.4,
+  "loss_multiplier": 0.7,
+  "bluff_call_bonus": 0.4,
+  "hand_type_bias": {"Three of a kind": 0.2, "Full house": 0.3},
   "greedy": false,
   "head": "pi"
 }

--- a/nfsp_ai/personality_specs/leshy.json
+++ b/nfsp_ai/personality_specs/leshy.json
@@ -1,0 +1,4 @@
+{
+  "name": "leshy",
+  "obs_blind_spots": ["public_priors"]
+}

--- a/nfsp_ai/personality_specs/leshy.json
+++ b/nfsp_ai/personality_specs/leshy.json
@@ -1,4 +1,6 @@
 {
   "name": "leshy",
-  "obs_blind_spots": ["public_priors"]
+  "obs_blind_spots": ["public_priors"],
+  "greedy": false,
+  "head": "pi"
 }

--- a/nfsp_ai/personality_specs/leshy.json
+++ b/nfsp_ai/personality_specs/leshy.json
@@ -1,6 +1,6 @@
 {
   "name": "leshy",
-  "obs_blind_spots": ["public_priors"],
+  "obs_blind_spots": ["private_priors", "last_bet_prob"],
   "greedy": false,
   "head": "pi"
 }

--- a/nfsp_ai/personality_specs/mavka.json
+++ b/nfsp_ai/personality_specs/mavka.json
@@ -2,5 +2,7 @@
   "name": "mavka",
   "win_multiplier": 0.8,
   "loss_multiplier": 2.5,
-  "bluff_caught_penalty": 0.5
+  "bluff_caught_penalty": 0.5,
+  "greedy": false,
+  "head": "pi"
 }

--- a/nfsp_ai/personality_specs/mavka.json
+++ b/nfsp_ai/personality_specs/mavka.json
@@ -1,0 +1,6 @@
+{
+  "name": "mavka",
+  "win_multiplier": 0.8,
+  "loss_multiplier": 2.5,
+  "bluff_caught_penalty": 0.5
+}

--- a/nfsp_ai/personality_specs/poludnica.json
+++ b/nfsp_ai/personality_specs/poludnica.json
@@ -1,0 +1,5 @@
+{
+  "name": "poludnica",
+  "loss_multiplier": 0.6,
+  "obs_blind_spots": ["round"]
+}

--- a/nfsp_ai/personality_specs/poludnica.json
+++ b/nfsp_ai/personality_specs/poludnica.json
@@ -1,5 +1,7 @@
 {
   "name": "poludnica",
   "loss_multiplier": 0.6,
-  "obs_blind_spots": ["round"]
+  "obs_blind_spots": ["round"],
+  "greedy": false,
+  "head": "pi"
 }

--- a/nfsp_ai/personality_specs/poludnica.json
+++ b/nfsp_ai/personality_specs/poludnica.json
@@ -1,7 +1,7 @@
 {
   "name": "poludnica",
   "loss_multiplier": 0.6,
-  "obs_blind_spots": ["round"],
+  "obs_blind_spots": ["history"],
   "greedy": false,
   "head": "pi"
 }

--- a/nfsp_ai/personality_specs/rusalka.json
+++ b/nfsp_ai/personality_specs/rusalka.json
@@ -1,0 +1,7 @@
+{
+  "name": "rusalka",
+  "hand_type_bias": {"Pair": 0.2, "Straight flush": 0.4, "Four of a kind": 0.3},
+  "bluff_caught_penalty": 0.2,
+  "greedy": false,
+  "head": "pi"
+}

--- a/nfsp_ai/personality_specs/veles.json
+++ b/nfsp_ai/personality_specs/veles.json
@@ -1,0 +1,7 @@
+{
+  "name": "veles",
+  "bluff_caught_penalty": 0.3,
+  "bluff_call_bonus": 0.3,
+  "greedy": false,
+  "head": "q"
+}

--- a/nfsp_ai/personality_specs/zorya.json
+++ b/nfsp_ai/personality_specs/zorya.json
@@ -1,0 +1,6 @@
+{
+  "name": "zorya",
+  "win_multiplier": 1.3,
+  "loss_multiplier": 1.3,
+  "obs_blind_spots": ["seat_counts"]
+}

--- a/nfsp_ai/personality_specs/zorya.json
+++ b/nfsp_ai/personality_specs/zorya.json
@@ -2,7 +2,7 @@
   "name": "zorya",
   "win_multiplier": 1.3,
   "loss_multiplier": 1.3,
-  "obs_blind_spots": ["seat_counts"],
+  "obs_blind_spots": ["seat_counts", "round"],
   "greedy": false,
   "head": "pi"
 }

--- a/nfsp_ai/personality_specs/zorya.json
+++ b/nfsp_ai/personality_specs/zorya.json
@@ -2,5 +2,7 @@
   "name": "zorya",
   "win_multiplier": 1.3,
   "loss_multiplier": 1.3,
-  "obs_blind_spots": ["seat_counts"]
+  "obs_blind_spots": ["seat_counts"],
+  "greedy": false,
+  "head": "pi"
 }

--- a/nfsp_ai/personality_train.py
+++ b/nfsp_ai/personality_train.py
@@ -1,0 +1,323 @@
+"""Training-time personality bias toolkit.
+
+Three mechanisms keyed on a single ``PersonalityTrainSpec``:
+
+  A. Terminal-magnitude shaping — multiply the MC terminal credit by a
+     per-trajectory scalar derived from the spec, the win/loss outcome, a
+     bluff oracle, and a hand-type bias keyed on the actor's bets.
+
+  B. Action-mask restriction — hard-zero forbidden bet ranges and (optionally)
+     the CHECK action, with a mandatory safety rail that always leaves at
+     least one legal action.
+
+  C. Observation feature zero-mask — zero named obs blocks at vectorize time
+     to produce trained-in perceptual deficits. The block layout mirrors
+     ``nfsp_ai.nfsp_run_local._compute_obs_dim`` and is resolved from the
+     same ``DeckSpec`` fields, so layout drift is impossible.
+
+The spec lives in a JSON file (one personality per file) and is also stamped
+into the exported inference checkpoint's ``cfg["personality"]`` so the
+production loader can reapply C and B at serve time symmetrically to training.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, asdict
+from typing import Optional, Sequence
+
+import numpy as np
+
+from shared.game_utils import (
+    GameRules,
+    determine_set_existence,
+    get_set_details_from_action_id,
+)
+
+
+# Hand-type strings as emitted by shared.game_utils.get_set_details_from_action_id.
+KNOWN_HAND_TYPES = (
+    "High card",
+    "Pair",
+    "Two pairs",
+    "Straight",
+    "Three of a kind",
+    "Full house",
+    "Flush",
+    "Four of a kind",
+    "Straight flush",
+)
+
+# Obs block names recognised by the blind-spot mask. Order matches the
+# layout produced by nfsp_ai.nfsp_run_local.vectorize_obs / _compute_obs_dim.
+KNOWN_OBS_BLOCKS = (
+    "private_hand",
+    "rules_jokers",
+    "private_jokers",
+    "common_jokers",
+    "common_hand",
+    "seat_counts",
+    "team_flags",       # only present when DeckSpec.team_aware is True
+    "round",
+    "history",
+    "last_bet_prob",
+    "private_priors",
+    "public_priors",
+    "blanks",
+)
+
+MAX_PLAYERS = 8  # mirrors nfsp_ai.nfsp_run_local.MAX_PLAYERS
+
+
+@dataclass(frozen=True)
+class PersonalityTrainSpec:
+    name: str
+    # --- A: terminal-magnitude shaping ---
+    win_multiplier: float = 1.0
+    loss_multiplier: float = 1.0
+    bluff_caught_penalty: float = 0.0       # added to loss scale when actor was caught bluffing
+    bluff_call_bonus: float = 0.0           # added to win scale when actor caught a bluff
+    hand_type_bias: dict = field(default_factory=dict)  # {set_type: float}; positive = likes
+    # --- B: action-mask restriction ---
+    forbid_hand_types: tuple = ()
+    forbid_check_unless_only: bool = False
+    # --- C: observation feature zero-mask ---
+    obs_blind_spots: tuple = ()
+
+
+def load_spec(path: str) -> PersonalityTrainSpec:
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    return spec_from_dict(data)
+
+
+def spec_to_dict(spec: PersonalityTrainSpec) -> dict:
+    d = asdict(spec)
+    d["forbid_hand_types"] = list(d["forbid_hand_types"])
+    d["obs_blind_spots"] = list(d["obs_blind_spots"])
+    return d
+
+
+def spec_from_dict(data: dict) -> PersonalityTrainSpec:
+    d = dict(data)
+    if "forbid_hand_types" in d:
+        d["forbid_hand_types"] = tuple(d["forbid_hand_types"])
+    if "obs_blind_spots" in d:
+        d["obs_blind_spots"] = tuple(d["obs_blind_spots"])
+    for ht in d.get("forbid_hand_types", ()):
+        if ht not in KNOWN_HAND_TYPES:
+            raise ValueError(
+                f"Unknown hand type {ht!r} in forbid_hand_types; known: {KNOWN_HAND_TYPES}"
+            )
+    for ht in (d.get("hand_type_bias") or {}):
+        if ht not in KNOWN_HAND_TYPES:
+            raise ValueError(
+                f"Unknown hand type {ht!r} in hand_type_bias; known: {KNOWN_HAND_TYPES}"
+            )
+    for blk in d.get("obs_blind_spots", ()):
+        if blk not in KNOWN_OBS_BLOCKS:
+            raise ValueError(
+                f"Unknown obs block {blk!r} in obs_blind_spots; known: {KNOWN_OBS_BLOCKS}"
+            )
+    return PersonalityTrainSpec(**d)
+
+
+# ---------------------------------------------------------------------------
+# Layout-block resolver (C)
+# ---------------------------------------------------------------------------
+
+def resolve_obs_block_slices(deck_spec) -> dict:
+    """Return ``{block_name: (start, end)}`` for every block in the obs vector.
+
+    Mirrors the order in ``nfsp_ai.nfsp_run_local.vectorize_obs`` /
+    ``_compute_obs_dim`` exactly. The resolver verifies the computed total
+    matches ``deck_spec.obs_dim`` so any drift in the obs layout fails fast.
+    """
+    card_dim = int(deck_spec.card_feature_dim)
+    history_dim = int(deck_spec.history_feature_dim)
+    hist_dim = int(deck_spec.hist_dim)
+    team_aware = bool(getattr(deck_spec, "team_aware", True))
+    slices: dict = {}
+    idx = 0
+
+    slices["private_hand"] = (idx, idx + card_dim); idx += card_dim
+    slices["rules_jokers"] = (idx, idx + 1); idx += 1
+    slices["private_jokers"] = (idx, idx + 1); idx += 1
+    slices["common_jokers"] = (idx, idx + 1); idx += 1
+    slices["common_hand"] = (idx, idx + card_dim); idx += card_dim
+    slices["seat_counts"] = (idx, idx + MAX_PLAYERS); idx += MAX_PLAYERS
+    if team_aware:
+        slices["team_flags"] = (idx, idx + MAX_PLAYERS); idx += MAX_PLAYERS
+    slices["round"] = (idx, idx + 1); idx += 1
+    slices["history"] = (idx, idx + history_dim); idx += history_dim
+    slices["last_bet_prob"] = (idx, idx + 1); idx += 1
+    slices["private_priors"] = (idx, idx + hist_dim); idx += hist_dim
+    slices["public_priors"] = (idx, idx + hist_dim); idx += hist_dim
+    slices["blanks"] = (idx, idx + 1); idx += 1
+
+    if idx != int(deck_spec.obs_dim):
+        raise ValueError(
+            f"Layout resolver computed obs_dim={idx} but DeckSpec.obs_dim="
+            f"{int(deck_spec.obs_dim)}. Layout out of sync with _compute_obs_dim."
+        )
+    return slices
+
+
+def apply_personality_to_obs(
+    obs: np.ndarray,
+    spec: Optional[PersonalityTrainSpec],
+    deck_spec,
+) -> np.ndarray:
+    """Zero the obs blocks named in ``spec.obs_blind_spots`` (in place)."""
+    if spec is None or not spec.obs_blind_spots:
+        return obs
+    layout = resolve_obs_block_slices(deck_spec)
+    for blk in spec.obs_blind_spots:
+        rng = layout.get(blk)
+        if rng is None:
+            # team_flags only exists when DeckSpec.team_aware; ignore silently.
+            continue
+        start, end = rng
+        obs[start:end] = 0.0
+    return obs
+
+
+# ---------------------------------------------------------------------------
+# Action-mask restriction (B)
+# ---------------------------------------------------------------------------
+
+_HAND_TYPE_ACTION_IDS_CACHE: dict = {}
+
+
+def _action_ids_for_hand_type(set_type: str, deck_size: int, check_id: int) -> list:
+    """Action ids in ``[0, check_id)`` whose decoded set_type matches.
+
+    Cached by (set_type, deck_size, check_id) — the partition is static for a
+    given deck.
+    """
+    key = (set_type, int(deck_size), int(check_id))
+    cached = _HAND_TYPE_ACTION_IDS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    ids: list = []
+    for aid in range(check_id):
+        info = get_set_details_from_action_id(aid, deck_size)
+        if info and info.get("set_type") == set_type:
+            ids.append(aid)
+    _HAND_TYPE_ACTION_IDS_CACHE[key] = ids
+    return ids
+
+
+def apply_personality_to_mask(
+    mask: np.ndarray,
+    spec: Optional[PersonalityTrainSpec],
+    deck_spec,
+) -> np.ndarray:
+    """Apply hard mask restrictions with a mandatory safety rail.
+
+    Order:
+      1. Snapshot the original mask and whether CHECK was originally legal.
+      2. Zero all bet ids matching ``spec.forbid_hand_types``.
+      3. If ``spec.forbid_check_unless_only`` and any bet is still legal, zero CHECK.
+      4. If the mask is now all zero, restore CHECK (if originally legal) or
+         fall back to the original mask. Never produce an empty mask.
+    """
+    if spec is None or (not spec.forbid_hand_types and not spec.forbid_check_unless_only):
+        return mask
+    check_id = int(deck_spec.check_action_id)
+    deck_size = int(deck_spec.deck_size)
+
+    original = mask.copy()
+    check_legal = bool(mask[check_id]) if check_id < len(mask) else False
+
+    for ht in spec.forbid_hand_types:
+        for aid in _action_ids_for_hand_type(ht, deck_size, check_id):
+            if aid < len(mask):
+                mask[aid] = 0
+
+    if spec.forbid_check_unless_only and check_id < len(mask):
+        bets_legal = bool(mask[:check_id].any()) if check_id > 0 else False
+        if bets_legal:
+            mask[check_id] = 0
+
+    if not mask.any():
+        if check_legal:
+            mask[check_id] = 1
+        else:
+            mask[:] = original
+    return mask
+
+
+# ---------------------------------------------------------------------------
+# Terminal-magnitude shaping (A)
+# ---------------------------------------------------------------------------
+
+def compute_personality_terminal_scale(
+    spec: Optional[PersonalityTrainSpec],
+    game_state: dict,
+    actor_nick: str,
+    loser_nick: Optional[str],
+    deck_size: int,
+) -> float:
+    """Compute the scalar multiplied into the MC terminal credit.
+
+    Returns 1.0 when no shaping applies. Mechanics:
+
+      * ``win_multiplier`` / ``loss_multiplier`` set the BASE scale.
+      * ``bluff_caught_penalty`` adds to the loss scale if the actor was the
+        bet-maker AND the bet was a bluff (the bet-maker lost the round).
+      * ``bluff_call_bonus`` adds to the win scale if the actor caught a bluff
+        (the actor was NOT the bet-maker and the bet-maker lost).
+      * ``hand_type_bias`` adds ``+bias`` to the scale per actor-bet of that
+        set_type when the actor won, and ``-bias`` when the actor lost — so
+        positive bias = the personality "likes" the hand type (wins bigger,
+        loses smaller) and negative = "dislikes" (wins smaller, loses bigger).
+    """
+    if spec is None or loser_nick is None:
+        return 1.0
+
+    actor_won = loser_nick != actor_nick
+    scale = float(spec.win_multiplier if actor_won else spec.loss_multiplier)
+
+    check_id = GameRules(int(deck_size)).check_action_id
+    history = game_state.get("history") or []
+
+    # Find the last bet and its maker.
+    bet_maker_nick: Optional[str] = None
+    last_bet_id = -1
+    for ev in reversed(history):
+        try:
+            aid = int(ev.get("action_id", -1))
+        except Exception:
+            continue
+        if 0 <= aid < check_id:
+            last_bet_id = aid
+            bet_maker_nick = ev.get("player")
+            break
+
+    bet_was_bluff = bet_maker_nick is not None and bet_maker_nick == loser_nick
+
+    if bet_was_bluff:
+        actor_was_bet_maker = bet_maker_nick == actor_nick
+        if actor_won and not actor_was_bet_maker:
+            scale += float(spec.bluff_call_bonus)
+        if (not actor_won) and actor_was_bet_maker:
+            scale += float(spec.bluff_caught_penalty)
+
+    if spec.hand_type_bias:
+        for ev in history:
+            if ev.get("player") != actor_nick:
+                continue
+            try:
+                aid = int(ev.get("action_id", -1))
+            except Exception:
+                continue
+            if not (0 <= aid < check_id):
+                continue
+            info = get_set_details_from_action_id(aid, int(deck_size))
+            if not info:
+                continue
+            bias = float(spec.hand_type_bias.get(info.get("set_type"), 0.0))
+            scale += bias if actor_won else -bias
+
+    return float(scale)

--- a/nfsp_ai/personality_train.py
+++ b/nfsp_ai/personality_train.py
@@ -83,6 +83,15 @@ class PersonalityTrainSpec:
     forbid_check_unless_only: bool = False
     # --- C: observation feature zero-mask ---
     obs_blind_spots: tuple = ()
+    # --- Inference-time variety (NOT used during training) ---
+    # greedy: True = argmax over the masked logits (deterministic, "stiff");
+    #         False = sample from softmax(masked_logits) (variety, less predictable).
+    # head:   "pi" = use the average policy (Nash-shaped); "q" = use the
+    #         best-response Q-net (sharper, more aggressive). "pi" + greedy=False
+    #         is the canonical "feels human" setting for trained personalities;
+    #         "q" + greedy=True is the perun "wall" setting (sculpted only today).
+    greedy: bool = True
+    head: str = "pi"
 
 
 def load_spec(path: str) -> PersonalityTrainSpec:
@@ -119,6 +128,9 @@ def spec_from_dict(data: dict) -> PersonalityTrainSpec:
             raise ValueError(
                 f"Unknown obs block {blk!r} in obs_blind_spots; known: {KNOWN_OBS_BLOCKS}"
             )
+    head = d.get("head", "pi")
+    if head not in ("pi", "q"):
+        raise ValueError(f"head must be 'pi' or 'q', got {head!r}")
     return PersonalityTrainSpec(**d)
 
 

--- a/nfsp_ai/production_agent.py
+++ b/nfsp_ai/production_agent.py
@@ -67,7 +67,10 @@ DEFAULT_GREEDY = os.environ.get("NFSP_GREEDY", "1") not in {"0", "false", "False
 # deployments without variant-specific files keep working unchanged.
 
 _INFERENCE_FILENAME_RE = re.compile(
-    r"^nfsp_inference_(?P<deck>24|32)(?:_(?P<variant>[A-Za-z0-9]+))?\.pt$"
+    r"^nfsp_inference_(?P<deck>24|32)"
+    r"(?:_(?P<variant>1v1|multi|team))?"
+    r"(?:_(?P<personality>[a-z]+))?"
+    r"\.pt$"
 )
 _KNOWN_VARIANTS = ("1v1", "multi", "team")
 
@@ -75,7 +78,9 @@ _KNOWN_VARIANTS = ("1v1", "multi", "team")
 def _model_key_from_filename(path: str) -> Optional[str]:
     """Map an inference file path to its routing key.
 
-    Returns None if the filename doesn't match the convention.
+    Returns None if the filename doesn't match the convention. Keys take
+    the form ``<deck>[_<variant>][_<personality>]`` — e.g. ``"24"``,
+    ``"24_1v1"``, ``"24_1v1_kupala"``, ``"24_kupala"``.
     """
     name = os.path.basename(path)
     m = _INFERENCE_FILENAME_RE.match(name)
@@ -83,12 +88,21 @@ def _model_key_from_filename(path: str) -> Optional[str]:
         return None
     deck = m.group("deck")
     variant = m.group("variant")
-    if variant is None:
-        return deck  # legacy
-    return f"{deck}_{variant}"
+    personality = m.group("personality")
+    parts = [deck]
+    if variant:
+        parts.append(variant)
+    if personality:
+        parts.append(personality)
+    return "_".join(parts)
 
 
-def _routing_keys(rules: dict, n_active: int, players: Optional[list] = None) -> list[str]:
+def _routing_keys(
+    rules: dict,
+    n_active: int,
+    players: Optional[list] = None,
+    personality: Optional[str] = None,
+) -> list[str]:
     """Return preferred routing keys, most-specific first.
 
     Routes by *active* player count (players with cards remaining), not
@@ -97,14 +111,21 @@ def _routing_keys(rules: dict, n_active: int, players: Optional[list] = None) ->
     provided the obs is canonicalized to drop eliminated seats before
     inference (see `_canonicalize_to_active`).
 
+    When ``personality`` is set (resolved from game_state via
+    ``personalities.resolve_personality``), personality-suffixed keys are
+    prepended to the chain so a trained-personality checkpoint wins over
+    the generic variant model. Existing variant-only keys remain as
+    fallback, so sculpted-only personalities (no trained checkpoint)
+    still route to the baseline and pick up the existing sculpting layer.
+
     The caller walks this list and picks the first key with a loaded
-    agent. Always ends with the bare `<deck>` legacy key so a
+    agent. Always ends with the bare ``<deck>`` legacy key so a
     single-model deployment continues to work.
 
-    Team mode is detected by inspecting `players[*].team` (the engine
-    schema). A players list with any non-None team value means team
-    mode. The legacy `rules.teams` flag is also honoured for callers
-    that pre-compute it.
+    Team mode is detected by inspecting ``players[*].team`` (the engine
+    schema). A players list with any non-None team value means team mode.
+    The legacy ``rules.teams`` flag is also honoured for callers that
+    pre-compute it.
     """
     deck = int(rules.get("deck_size", 24))
     is_team = bool(rules.get("teams", False))
@@ -116,6 +137,19 @@ def _routing_keys(rules: dict, n_active: int, players: Optional[list] = None) ->
     is_1v1 = (n_active == 2 and j == 0 and b == 0 and cc == 0 and not is_team)
 
     keys: list[str] = []
+
+    # Personality-keyed candidates (most specific first). Only prepended when
+    # a personality was resolved from game_state. If no trained checkpoint
+    # exists for any of these, the variant-only fallback below catches it.
+    if personality:
+        if is_team:
+            keys.append(f"{deck}_team_{personality}")
+        if is_1v1:
+            keys.append(f"{deck}_1v1_{personality}")
+        keys.append(f"{deck}_multi_{personality}")
+        keys.append(f"{deck}_{personality}")
+
+    # Variant-only fallback chain (the original routing).
     if is_team:
         keys.append(f"{deck}_team")
     if is_1v1:
@@ -283,12 +317,17 @@ class NFSPProductionAgent:
         self.history_embeddings = _load_history_embedding_map(history_embedding_path, self.device)
 
         # agents: routing-key -> NFSPAgent
-        # routing-key examples: "24" (legacy), "24_1v1", "24_multi", "32_team"
+        # routing-key examples: "24" (legacy), "24_1v1", "24_multi", "32_team",
+        # "24_1v1_kupala", "24_kupala", etc.
         self.agents: dict[str, NFSPAgent] = {}
         self.model_sources: dict[str, str] = {}
         # team_aware per loaded model: chosen at determine_action time
         # to build the right-shape obs for the served checkpoint.
         self.agent_team_aware: dict[str, bool] = {}
+        # personality_spec per loaded model when stamped (training was driven
+        # by --personality-spec). Reapplied at serve time so the obs blind
+        # spots and mask restrictions match the training distribution.
+        self.agent_personality_spec: dict = {}
         for key, cand in _resolve_model_paths(model_path).items():
             ckpt = torch.load(cand, map_location=self.device)
             act_dim = int(ckpt.get("act_dim", 0))
@@ -315,6 +354,39 @@ class NFSPProductionAgent:
             self.agents[key] = agent
             self.model_sources[key] = cand
             cfg = ckpt.get("cfg") or {}
+            # Rehydrate the stamped personality spec, if present. Warn (but do
+            # not fail) when the stamped spec diverges from the on-disk spec
+            # at nfsp_ai/personality_specs/<name>.json — the checkpoint's
+            # stamped value is the contract, the on-disk spec is the source
+            # the next training run would use.
+            pers_dict = cfg.get("personality")
+            if pers_dict is not None:
+                try:
+                    from nfsp_ai.personality_train import spec_from_dict, load_spec, spec_to_dict
+                    stamped_spec = spec_from_dict(pers_dict)
+                    self.agent_personality_spec[key] = stamped_spec
+                    disk_path = f"nfsp_ai/personality_specs/{stamped_spec.name}.json"
+                    if os.path.exists(disk_path):
+                        try:
+                            disk_spec = load_spec(disk_path)
+                            if spec_to_dict(disk_spec) != spec_to_dict(stamped_spec):
+                                logger.warning(
+                                    "personality spec stamped on %s differs from %s; "
+                                    "serving the stamped spec.",
+                                    cand,
+                                    disk_path,
+                                )
+                        except Exception:
+                            logger.exception(
+                                "could not validate on-disk spec %s; continuing with stamped.",
+                                disk_path,
+                            )
+                except Exception:
+                    logger.exception(
+                        "failed to rehydrate cfg['personality'] on %s; "
+                        "this trained-personality checkpoint will serve as a baseline.",
+                        cand,
+                    )
             cfg_team_aware = cfg.get("team_aware")
             if cfg_team_aware is None:
                 self.agent_team_aware[key] = self._infer_team_aware(deck_size, int(ckpt["obs_dim"]))
@@ -431,7 +503,7 @@ class NFSPProductionAgent:
         players = game_state.get("players", []) or []
         n_seated = len(players)
         n_active = sum(1 for p in players if int(p.get("n_cards", 0)) > 0)
-        keys = _routing_keys(rules, n_active, players=players)
+        keys = _routing_keys(rules, n_active, players=players, personality=pers_name)
         agent = None
         chosen_key = None
         for key in keys:
@@ -451,7 +523,10 @@ class NFSPProductionAgent:
         # training distribution. multi/team specialists trained on
         # games that include eliminations and expect the seat block
         # to retain eliminated slots, so they pass through unchanged.
-        if chosen_key and chosen_key.endswith("_1v1") and n_active < n_seated:
+        # Personality variants inherit the same canonicalization rule from
+        # their underlying variant (1v1/multi/team) — the personality suffix
+        # doesn't change the seat semantics.
+        if chosen_key and ("_1v1" in chosen_key) and n_active < n_seated:
             game_state = _canonicalize_to_active(game_state)
         # Embeddings remain keyed by deck size; variant doesn't change
         # the card / history vocabulary.
@@ -468,6 +543,13 @@ class NFSPProductionAgent:
             history_embedding=history_embedding,
             team_aware=spec_team_aware,
         )
+        # Attach the rehydrated personality spec (if any) to the deck_spec so
+        # vectorize_obs and _legal_action_mask reapply the obs blind-spots /
+        # mask restrictions symmetrically to training. Absent for baseline
+        # and sculpted-only personalities.
+        trained_personality_spec = self.agent_personality_spec.get(chosen_key)
+        if trained_personality_spec is not None:
+            spec.personality_spec = trained_personality_spec
         obs_vec, pub_prior = vectorize_obs(
             game_state,
             cp,
@@ -485,7 +567,11 @@ class NFSPProductionAgent:
         # NFSP-backed personality: sculpt the chosen head's logits. Any failure
         # falls back to the unmodified baseline policy so a bad config can never
         # take a bot offline.
-        if pers_name is not None:
+        # SKIP sculpting when a trained-personality checkpoint is serving — the
+        # bias is already baked into the policy weights, and overlaying sculpt
+        # logits on top would distort it. Sculpting still runs when the
+        # resolved personality has no trained checkpoint (existing pantheon).
+        if pers_name is not None and trained_personality_spec is None:
             try:
                 return int(personalities.personality_action(
                     agent, obs_tensor, mask_tensor, game_state, spec, pub_prior, pers_name))

--- a/nfsp_ai/production_agent.py
+++ b/nfsp_ai/production_agent.py
@@ -579,11 +579,24 @@ class NFSPProductionAgent:
                 logger.exception(
                     "personality_action failed for '%s'; using baseline policy", pers_name)
 
+        # Per-personality variety knobs (greedy / head) when serving a TRAINED
+        # personality. Default head="pi" (Nash-shaped avg policy) and
+        # greedy=True (deterministic argmax) — same as baseline. A spec can
+        # opt into greedy=False (sample from softmax(masked_logits) -> less
+        # stiff, more varied) or head="q" (use best-response Q-net -> sharper
+        # / more aggressive). Baseline and sculpted-only personalities keep
+        # the existing global `self.greedy` and pi-head behavior.
+        use_avg_policy = True
+        be_greedy = self.greedy
+        if trained_personality_spec is not None:
+            use_avg_policy = (trained_personality_spec.head == "pi")
+            be_greedy = bool(trained_personality_spec.greedy)
+
         action = agent.select_action(
             obs_tensor,
             mask_tensor,
-            use_average_policy=True,
-            greedy=self.greedy,
+            use_average_policy=use_avg_policy,
+            greedy=be_greedy,
         )
         return int(action)
 

--- a/nfsp_ai/production_agent.py
+++ b/nfsp_ai/production_agent.py
@@ -207,6 +207,40 @@ def _canonicalize_to_active(game_state: dict) -> dict:
     return out
 
 
+_PUB_PRIOR_EPSILON = 1e-9
+
+
+def _filter_mask_by_public_priors(
+    mask: torch.Tensor, pub_prior, check_action_id: int
+) -> torch.Tensor:
+    """Zero mask entries for bet actions whose public-prior probability is
+    effectively zero. Public priors encode "given visible cards alone, is
+    this set even reachable?" — a 0 means the bet is provably-impossible
+    regardless of hidden hands (e.g. Full house with only 4 cards in play).
+
+    Applied at inference only — training-time masks intentionally keep these
+    actions legal (per PR #40, hard-zeroing them in training tied the action
+    set to a buggy probability calculator). At inference, we never want a
+    bot betting a provably-impossible set; it reads as a bug, not a trait.
+
+    Safety rail: if filtering would zero the mask (rare — only when CHECK is
+    also illegal, i.e. the round has resolved), the original mask is
+    returned unchanged.
+    """
+    if pub_prior is None:
+        return mask
+    pub_arr = np.asarray(pub_prior, dtype=np.float32)
+    if pub_arr.size == 0:
+        return mask
+    n = int(min(pub_arr.size, check_action_id))
+    plausible = (pub_arr[:n] > _PUB_PRIOR_EPSILON)
+    mask_np = mask.detach().cpu().numpy().astype(np.float32, copy=True)
+    mask_np[:n] = mask_np[:n] * plausible.astype(np.float32)
+    if mask_np.sum() <= 0:
+        return mask
+    return torch.from_numpy(mask_np).to(mask.dtype)
+
+
 def _resolve_model_paths(path: Optional[str]) -> dict[str, str]:
     """Discover inference checkpoints. Returns {routing_key: path}.
 
@@ -579,6 +613,9 @@ class NFSPProductionAgent:
         mask = _legal_action_mask(game_state, spec, pub_prior)
         if mask.sum() <= 0:
             raise RuntimeError("No legal actions available for current game state")
+        # Inference-only sanity floor: forbid bets the public information
+        # already proves impossible (e.g. Full house with 4 cards in play).
+        mask = _filter_mask_by_public_priors(mask, pub_prior, int(spec.check_action_id))
 
         obs_tensor = torch.from_numpy(np.asarray(obs_vec, dtype=np.float32)).to(self.device)
         mask_tensor = mask.to(device=self.device, dtype=torch.float32)

--- a/nfsp_ai/production_agent.py
+++ b/nfsp_ai/production_agent.py
@@ -141,6 +141,17 @@ def _routing_keys(
     # Personality-keyed candidates (most specific first). Only prepended when
     # a personality was resolved from game_state. If no trained checkpoint
     # exists for any of these, the variant-only fallback below catches it.
+    #
+    # Design choice: trained personalities exist to be UNIQUE, not stronger.
+    # So when a variant-specific personality ckpt doesn't exist, fall through
+    # to the trained `<deck>_1v1_<personality>` ckpt even on multi/team games
+    # — the obs schema is compatible for non-team variants (the 1v1 ckpt has
+    # team_aware=False, obs_dim matches non-team obs of the same deck), and
+    # the cost is "personality plays its trait without variant-specific
+    # strategic refinement" — which is exactly the trade we want. For team
+    # mode the obs would mismatch, so the variant-only fallback catches it
+    # (team_aware base NFSP + sculpt overlay) — see the trade-off table in
+    # PR #70's description.
     if personality:
         if is_team:
             keys.append(f"{deck}_team_{personality}")
@@ -148,6 +159,14 @@ def _routing_keys(
             keys.append(f"{deck}_1v1_{personality}")
         keys.append(f"{deck}_multi_{personality}")
         keys.append(f"{deck}_{personality}")
+        # Cross-variant trained-personality fallback: prefer the 1v1 trained
+        # ckpt over the generic variant baseline whenever the obs schema is
+        # compatible. Compatibility = NOT team mode (1v1-trained checkpoints
+        # have team_aware=False; building the obs without team flags matches
+        # their input shape). For team mode, the variant-only fallback chain
+        # below applies instead (sculpt overlay on team-trained NFSP).
+        if not is_1v1 and not is_team:
+            keys.append(f"{deck}_1v1_{personality}")
 
     # Variant-only fallback chain (the original routing).
     if is_team:

--- a/nfsp_ai/scripts/deploy_lambda.sh
+++ b/nfsp_ai/scripts/deploy_lambda.sh
@@ -6,15 +6,27 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 NFSP_DIR="${ROOT_DIR}/nfsp_ai"
 IMAGE_NAME="blef-nfsp-lambda:lambda-compatible"
 
+# AWS auth: honour AWS_PROFILE when set; otherwise fall back to whatever
+# auth chain the aws CLI finds on its own (env vars, default profile,
+# IAM role, etc.). Passing --profile explicitly surfaces typos and
+# avoids ambiguity when multiple auth sources are configured.
+AWS_ARGS=()
+if [[ -n "${AWS_PROFILE:-}" ]]; then
+  AWS_ARGS=(--profile "${AWS_PROFILE}")
+fi
+
 if [[ -z "${ACCT:-}" || -z "${REGION:-}" ]]; then
   cat <<EOF
 Environment variables ACCT and REGION must be set before running this script.
-  ACCT   – AWS account ID (numeric)
-  REGION – AWS region code (e.g., us-east-1)
+  ACCT         – AWS account ID (numeric)
+  REGION       – AWS region code (e.g., us-east-1)
+  AWS_PROFILE  – (optional) named AWS profile to use; if unset, the
+                 default credentials chain is used.
 
 Example:
   export ACCT=123456789012
   export REGION=us-east-1
+  export AWS_PROFILE=blef-deploy    # optional
 EOF
   exit 1
 fi
@@ -27,6 +39,16 @@ if ! command -v docker >/dev/null 2>&1; then
   echo "[error] docker not found in PATH" >&2
   exit 1
 fi
+
+# Pre-flight auth check: fail fast (before the Docker build) if creds are
+# wrong. Reports the resolved identity so the operator can sanity-check
+# they're pointing at the right account.
+if ! WHOAMI="$(aws "${AWS_ARGS[@]}" sts get-caller-identity --region "${REGION}" --output text 2>&1)"; then
+  echo "[error] aws sts get-caller-identity failed${AWS_PROFILE:+ (AWS_PROFILE=${AWS_PROFILE})}:" >&2
+  echo "  ${WHOAMI}" >&2
+  exit 1
+fi
+echo "[auth] caller identity: ${WHOAMI}${AWS_PROFILE:+  (profile=${AWS_PROFILE})}"
 
 declare -a REQUIRED_ARTIFACTS=(
   "artifacts/nfsp_inference_24.pt"
@@ -71,7 +93,7 @@ TAG="${TAG:-lambda-compatible}"
 ECR="${ACCT}.dkr.ecr.${REGION}.amazonaws.com/${REPO}:${TAG}"
 
 echo "[login] Logging into ECR ${ACCT}.dkr.ecr.${REGION}.amazonaws.com"
-aws ecr get-login-password --region "${REGION}" \
+aws "${AWS_ARGS[@]}" ecr get-login-password --region "${REGION}" \
   | docker login --username AWS --password-stdin "${ACCT}.dkr.ecr.${REGION}.amazonaws.com"
 
 echo "[tag] Tagging image ${IMAGE_NAME} -> ${ECR}"
@@ -85,11 +107,12 @@ FUNCTION="${FUNCTION:-blef-aiagent-nfsp}"
 # touching production. Swap explicitly (SWAP=1) once the new image is verified.
 if [[ "${SWAP:-0}" == "1" ]]; then
   echo "[lambda] Updating Lambda function ${FUNCTION} to image ${ECR}"
-  aws lambda update-function-code \
+  aws "${AWS_ARGS[@]}" lambda update-function-code \
     --function-name "${FUNCTION}" \
+    --region "${REGION}" \
     --image-uri "${ECR}"
   echo "[done] Build, push and SWAP complete."
 else
   echo "[skip] SWAP!=1 — pushed image ${ECR} but did NOT update ${FUNCTION}."
-  echo "       To swap:  aws lambda update-function-code --function-name ${FUNCTION} --image-uri ${ECR} --region ${REGION}"
+  echo "       To swap:  aws${AWS_PROFILE:+ --profile ${AWS_PROFILE}} lambda update-function-code --function-name ${FUNCTION} --image-uri ${ECR} --region ${REGION}"
 fi

--- a/nfsp_ai/scripts/deploy_lambda.sh
+++ b/nfsp_ai/scripts/deploy_lambda.sh
@@ -27,7 +27,7 @@ fi
 # Pre-flight auth check: fail fast (before the Docker build) if creds are
 # wrong. Also doubles as the source of truth for ACCT when ACCT is not
 # explicitly set — pulls the account id directly from sts.
-if ! STS_OUT="$(aws "${AWS_ARGS[@]}" sts get-caller-identity --output text 2>&1)"; then
+if ! STS_OUT="$(aws ${AWS_ARGS[@]+"${AWS_ARGS[@]}"} sts get-caller-identity --output text 2>&1)"; then
   echo "[error] aws sts get-caller-identity failed${AWS_PROFILE:+ (AWS_PROFILE=${AWS_PROFILE})}:" >&2
   echo "  ${STS_OUT}" >&2
   echo "  Configure the aws CLI (\`aws sso login\`, \`aws configure\`, or set" >&2
@@ -46,7 +46,7 @@ fi
 # REGION resolution: explicit env var > AWS_DEFAULT_REGION > the active
 # CLI/profile's configured region. Hard-fail only when all three are empty.
 if [[ -z "${REGION:-}" ]]; then
-  REGION="${AWS_DEFAULT_REGION:-$(aws "${AWS_ARGS[@]}" configure get region 2>/dev/null || true)}"
+  REGION="${AWS_DEFAULT_REGION:-$(aws ${AWS_ARGS[@]+"${AWS_ARGS[@]}"} configure get region 2>/dev/null || true)}"
 fi
 if [[ -z "${REGION:-}" ]]; then
   cat <<EOF >&2
@@ -105,7 +105,7 @@ TAG="${TAG:-lambda-compatible}"
 ECR="${ACCT}.dkr.ecr.${REGION}.amazonaws.com/${REPO}:${TAG}"
 
 echo "[login] Logging into ECR ${ACCT}.dkr.ecr.${REGION}.amazonaws.com"
-aws "${AWS_ARGS[@]}" ecr get-login-password --region "${REGION}" \
+aws ${AWS_ARGS[@]+"${AWS_ARGS[@]}"} ecr get-login-password --region "${REGION}" \
   | docker login --username AWS --password-stdin "${ACCT}.dkr.ecr.${REGION}.amazonaws.com"
 
 echo "[tag] Tagging image ${IMAGE_NAME} -> ${ECR}"
@@ -119,7 +119,7 @@ FUNCTION="${FUNCTION:-blef-aiagent-nfsp}"
 # touching production. Swap explicitly (SWAP=1) once the new image is verified.
 if [[ "${SWAP:-0}" == "1" ]]; then
   echo "[lambda] Updating Lambda function ${FUNCTION} to image ${ECR}"
-  aws "${AWS_ARGS[@]}" lambda update-function-code \
+  aws ${AWS_ARGS[@]+"${AWS_ARGS[@]}"} lambda update-function-code \
     --function-name "${FUNCTION}" \
     --region "${REGION}" \
     --image-uri "${ECR}"

--- a/nfsp_ai/scripts/deploy_lambda.sh
+++ b/nfsp_ai/scripts/deploy_lambda.sh
@@ -15,22 +15,6 @@ if [[ -n "${AWS_PROFILE:-}" ]]; then
   AWS_ARGS=(--profile "${AWS_PROFILE}")
 fi
 
-if [[ -z "${ACCT:-}" || -z "${REGION:-}" ]]; then
-  cat <<EOF
-Environment variables ACCT and REGION must be set before running this script.
-  ACCT         – AWS account ID (numeric)
-  REGION       – AWS region code (e.g., us-east-1)
-  AWS_PROFILE  – (optional) named AWS profile to use; if unset, the
-                 default credentials chain is used.
-
-Example:
-  export ACCT=123456789012
-  export REGION=us-east-1
-  export AWS_PROFILE=blef-deploy    # optional
-EOF
-  exit 1
-fi
-
 if ! command -v aws >/dev/null 2>&1; then
   echo "[error] aws CLI not found in PATH" >&2
   exit 1
@@ -41,14 +25,42 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 # Pre-flight auth check: fail fast (before the Docker build) if creds are
-# wrong. Reports the resolved identity so the operator can sanity-check
-# they're pointing at the right account.
-if ! WHOAMI="$(aws "${AWS_ARGS[@]}" sts get-caller-identity --region "${REGION}" --output text 2>&1)"; then
+# wrong. Also doubles as the source of truth for ACCT when ACCT is not
+# explicitly set — pulls the account id directly from sts.
+if ! STS_OUT="$(aws "${AWS_ARGS[@]}" sts get-caller-identity --output text 2>&1)"; then
   echo "[error] aws sts get-caller-identity failed${AWS_PROFILE:+ (AWS_PROFILE=${AWS_PROFILE})}:" >&2
-  echo "  ${WHOAMI}" >&2
+  echo "  ${STS_OUT}" >&2
+  echo "  Configure the aws CLI (\`aws sso login\`, \`aws configure\`, or set" >&2
+  echo "  AWS_PROFILE / standard AWS_* env vars), then retry." >&2
   exit 1
 fi
-echo "[auth] caller identity: ${WHOAMI}${AWS_PROFILE:+  (profile=${AWS_PROFILE})}"
+# STS output is tab-separated: "AccountId  ARN  UserId" (with the default
+# --output text format). Pull the first field as the account id.
+ACCT_FROM_STS="$(awk '{print $1}' <<<"${STS_OUT}")"
+ACCT="${ACCT:-${ACCT_FROM_STS}}"
+if [[ "${ACCT}" != "${ACCT_FROM_STS}" ]]; then
+  echo "[warn] explicit ACCT (${ACCT}) differs from current caller identity account (${ACCT_FROM_STS})" >&2
+  echo "       continuing with ACCT=${ACCT} — make sure that's intended" >&2
+fi
+
+# REGION resolution: explicit env var > AWS_DEFAULT_REGION > the active
+# CLI/profile's configured region. Hard-fail only when all three are empty.
+if [[ -z "${REGION:-}" ]]; then
+  REGION="${AWS_DEFAULT_REGION:-$(aws "${AWS_ARGS[@]}" configure get region 2>/dev/null || true)}"
+fi
+if [[ -z "${REGION:-}" ]]; then
+  cat <<EOF >&2
+[error] could not determine an AWS region.
+Set one of:
+  REGION=eu-west-2 ./nfsp_ai/scripts/deploy_lambda.sh
+  export AWS_DEFAULT_REGION=eu-west-2
+  aws configure set region eu-west-2 ${AWS_PROFILE:+--profile ${AWS_PROFILE}}
+EOF
+  exit 1
+fi
+
+echo "[auth] caller identity: ${STS_OUT}${AWS_PROFILE:+  (profile=${AWS_PROFILE})}"
+echo "[auth] using ACCT=${ACCT}  REGION=${REGION}"
 
 declare -a REQUIRED_ARTIFACTS=(
   "artifacts/nfsp_inference_24.pt"

--- a/tests/test_personality_train.py
+++ b/tests/test_personality_train.py
@@ -1,0 +1,308 @@
+"""Unit tests for nfsp_ai.personality_train.
+
+Covers:
+  - PersonalityTrainSpec JSON round-trip and validation
+  - layout-block resolver: disjoint + contiguous + matches DeckSpec.obs_dim
+  - apply_personality_to_obs: zeroes exactly the named slice
+  - apply_personality_to_mask: safety rail always leaves ≥1 legal action
+  - compute_personality_terminal_scale: win/loss multipliers + bluff oracle
+    + hand-type bias
+"""
+
+import json
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import torch
+
+from nfsp_ai.nfsp_run_local import _build_deck_spec
+from nfsp_ai.personality_train import (
+    PersonalityTrainSpec,
+    apply_personality_to_mask,
+    apply_personality_to_obs,
+    compute_personality_terminal_scale,
+    load_spec,
+    resolve_obs_block_slices,
+    spec_from_dict,
+    spec_to_dict,
+)
+
+
+class TestSpecRoundTrip(unittest.TestCase):
+    def test_dict_round_trip_preserves_fields(self):
+        s = PersonalityTrainSpec(
+            name="testbot",
+            win_multiplier=1.5,
+            loss_multiplier=2.0,
+            bluff_caught_penalty=0.3,
+            hand_type_bias={"Pair": -0.4, "Flush": 0.2},
+            forbid_hand_types=("Pair",),
+            forbid_check_unless_only=True,
+            obs_blind_spots=("history", "common_jokers"),
+        )
+        d = spec_to_dict(s)
+        # tuples become lists in dict form (JSON-safe)
+        self.assertEqual(d["forbid_hand_types"], ["Pair"])
+        self.assertEqual(d["obs_blind_spots"], ["history", "common_jokers"])
+        # round-trip
+        s2 = spec_from_dict(d)
+        self.assertEqual(s2, s)
+
+    def test_load_spec_from_disk(self):
+        s = PersonalityTrainSpec(
+            name="testbot",
+            obs_blind_spots=("history",),
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(spec_to_dict(s), f)
+            path = f.name
+        try:
+            loaded = load_spec(path)
+            self.assertEqual(loaded, s)
+        finally:
+            os.unlink(path)
+
+    def test_invalid_hand_type_rejected(self):
+        with self.assertRaises(ValueError):
+            spec_from_dict({"name": "bad", "forbid_hand_types": ["Bogus"]})
+        with self.assertRaises(ValueError):
+            spec_from_dict({"name": "bad", "hand_type_bias": {"Bogus": 0.5}})
+
+    def test_invalid_obs_block_rejected(self):
+        with self.assertRaises(ValueError):
+            spec_from_dict({"name": "bad", "obs_blind_spots": ["wibble"]})
+
+
+class TestLayoutResolver(unittest.TestCase):
+    """The block-slice resolver must match _compute_obs_dim exactly."""
+
+    def _deck_spec(self, team_aware: bool, deck_size: int = 24):
+        return _build_deck_spec(
+            {"deck_size": deck_size},
+            card_embedding=None,
+            history_embedding=None,
+            team_aware=team_aware,
+        )
+
+    def test_layout_disjoint_and_contiguous_team_aware(self):
+        spec = self._deck_spec(team_aware=True)
+        slices = resolve_obs_block_slices(spec)
+        self.assertIn("team_flags", slices)
+        cov = 0
+        for blk, (s, e) in sorted(slices.items(), key=lambda kv: kv[1][0]):
+            self.assertEqual(s, cov, f"gap before block {blk!r}")
+            self.assertLess(s, e, f"empty block {blk!r}")
+            cov = e
+        self.assertEqual(cov, spec.obs_dim)
+
+    def test_layout_disjoint_and_contiguous_no_team(self):
+        spec = self._deck_spec(team_aware=False)
+        slices = resolve_obs_block_slices(spec)
+        self.assertNotIn("team_flags", slices)
+        cov = 0
+        for blk, (s, e) in sorted(slices.items(), key=lambda kv: kv[1][0]):
+            self.assertEqual(s, cov, f"gap before block {blk!r}")
+            cov = e
+        self.assertEqual(cov, spec.obs_dim)
+
+
+class TestObsZeroMask(unittest.TestCase):
+    def setUp(self):
+        self.spec = _build_deck_spec(
+            {"deck_size": 24}, None, None, team_aware=True
+        )
+        self.layout = resolve_obs_block_slices(self.spec)
+
+    def test_blanks_only_named_slice(self):
+        obs = np.ones(self.spec.obs_dim, dtype=np.float32)
+        ps = spec_from_dict({"name": "t", "obs_blind_spots": ["history"]})
+        apply_personality_to_obs(obs, ps, self.spec)
+        hs, he = self.layout["history"]
+        # Named slice zeroed:
+        self.assertEqual(float(obs[hs:he].sum()), 0.0)
+        # Every other dim untouched:
+        nonzero = int((obs != 0).sum())
+        self.assertEqual(nonzero, self.spec.obs_dim - (he - hs))
+
+    def test_multiple_blocks(self):
+        obs = np.ones(self.spec.obs_dim, dtype=np.float32)
+        ps = spec_from_dict(
+            {"name": "t", "obs_blind_spots": ["history", "common_jokers", "blanks"]}
+        )
+        apply_personality_to_obs(obs, ps, self.spec)
+        for blk in ("history", "common_jokers", "blanks"):
+            s, e = self.layout[blk]
+            self.assertEqual(float(obs[s:e].sum()), 0.0, f"{blk} not zeroed")
+
+    def test_none_spec_no_op(self):
+        obs = np.ones(self.spec.obs_dim, dtype=np.float32)
+        apply_personality_to_obs(obs, None, self.spec)
+        self.assertEqual(int(obs.sum()), self.spec.obs_dim)
+
+    def test_missing_block_silently_skipped(self):
+        # team_flags only exists when DeckSpec.team_aware; for a no-team spec
+        # asking to zero "team_flags" should silently no-op.
+        spec_noteam = _build_deck_spec(
+            {"deck_size": 24}, None, None, team_aware=False
+        )
+        obs = np.ones(spec_noteam.obs_dim, dtype=np.float32)
+        ps = spec_from_dict({"name": "t", "obs_blind_spots": ["team_flags"]})
+        # Should NOT raise; all dims stay intact.
+        apply_personality_to_obs(obs, ps, spec_noteam)
+        self.assertEqual(int(obs.sum()), spec_noteam.obs_dim)
+
+
+class TestMaskRestriction(unittest.TestCase):
+    def setUp(self):
+        self.spec = _build_deck_spec(
+            {"deck_size": 24}, None, None, team_aware=True
+        )
+        self.check_id = self.spec.check_action_id
+
+    def _full_mask(self):
+        m = np.ones(self.spec.num_actions, dtype=np.float32)
+        return m
+
+    def test_forbid_pair_zeros_pair_action_ids(self):
+        ps = spec_from_dict({"name": "t", "forbid_hand_types": ["Pair"]})
+        m = self._full_mask()
+        apply_personality_to_mask(m, ps, self.spec)
+        # 24-deck Pair = ids 6..11
+        self.assertEqual(float(m[6:12].sum()), 0.0)
+        # Other bets still legal
+        self.assertGreater(float(m[12:self.check_id].sum()), 0.0)
+        # CHECK preserved
+        self.assertEqual(float(m[self.check_id]), 1.0)
+
+    def test_forbid_check_unless_only_zeros_check_when_bets_legal(self):
+        ps = spec_from_dict({"name": "t", "forbid_check_unless_only": True})
+        m = self._full_mask()
+        apply_personality_to_mask(m, ps, self.spec)
+        # Bets are legal so CHECK should be masked
+        self.assertEqual(float(m[self.check_id]), 0.0)
+        self.assertGreater(float(m[:self.check_id].sum()), 0.0)
+
+    def test_safety_rail_when_only_check_was_legal(self):
+        """If forbid_check_unless_only would empty the mask, the rail lifts."""
+        ps = spec_from_dict({"name": "t", "forbid_check_unless_only": True})
+        m = np.zeros(self.spec.num_actions, dtype=np.float32)
+        m[self.check_id] = 1  # only CHECK is legal
+        apply_personality_to_mask(m, ps, self.spec)
+        # Safety rail must restore CHECK; never empty mask.
+        self.assertEqual(float(m[self.check_id]), 1.0)
+
+    def test_safety_rail_when_all_bets_were_forbidden_types(self):
+        """If the entire legal-bet set falls in forbidden types, restore CHECK."""
+        ps = spec_from_dict(
+            {"name": "t", "forbid_hand_types": ["Pair"]}
+        )
+        m = np.zeros(self.spec.num_actions, dtype=np.float32)
+        # Only Pair bets legal + CHECK
+        m[6:12] = 1
+        m[self.check_id] = 1
+        apply_personality_to_mask(m, ps, self.spec)
+        # CHECK still legal (safety rail)
+        self.assertEqual(float(m[self.check_id]), 1.0)
+
+    def test_none_spec_no_op(self):
+        m = self._full_mask()
+        apply_personality_to_mask(m, None, self.spec)
+        self.assertEqual(int(m.sum()), self.spec.num_actions)
+
+
+class TestTerminalScale(unittest.TestCase):
+    """compute_personality_terminal_scale: win/loss + bluff + hand-type."""
+
+    def _gs(self, history):
+        return {"history": history}
+
+    def test_no_op_when_spec_none(self):
+        gs = self._gs([{"player": "A", "action_id": 5}])
+        self.assertEqual(
+            compute_personality_terminal_scale(None, gs, "A", "A", 24),
+            1.0,
+        )
+
+    def test_no_op_when_loser_none(self):
+        ps = spec_from_dict({"name": "t", "loss_multiplier": 99.0})
+        gs = self._gs([])
+        self.assertEqual(
+            compute_personality_terminal_scale(ps, gs, "A", None, 24),
+            1.0,
+        )
+
+    def test_win_multiplier_applied(self):
+        ps = spec_from_dict({"name": "t", "win_multiplier": 1.5})
+        gs = self._gs([{"player": "B", "action_id": 5}])  # B bet, A checked, B lost.
+        # actor=A, loser=B → A won → win_mult applies
+        self.assertAlmostEqual(
+            compute_personality_terminal_scale(ps, gs, "A", "B", 24), 1.5
+        )
+
+    def test_loss_multiplier_applied(self):
+        ps = spec_from_dict({"name": "t", "loss_multiplier": 2.0})
+        gs = self._gs([{"player": "A", "action_id": 5}])
+        # actor=A, loser=A → A lost → loss_mult
+        self.assertAlmostEqual(
+            compute_personality_terminal_scale(ps, gs, "A", "A", 24), 2.0
+        )
+
+    def test_bluff_caught_penalty_on_self_caught(self):
+        ps = spec_from_dict(
+            {"name": "t", "loss_multiplier": 2.0, "bluff_caught_penalty": 0.5}
+        )
+        # A bet (last bet), B checked. A lost (the bet-maker lost → bluff).
+        gs = self._gs([{"player": "A", "action_id": 5}])
+        self.assertAlmostEqual(
+            compute_personality_terminal_scale(ps, gs, "A", "A", 24), 2.5
+        )
+
+    def test_bluff_call_bonus_on_catching_bluff(self):
+        ps = spec_from_dict(
+            {"name": "t", "win_multiplier": 1.0, "bluff_call_bonus": 0.3}
+        )
+        # B bet (last bet), A checked. B lost → A caught a bluff.
+        gs = self._gs([{"player": "B", "action_id": 5}])
+        self.assertAlmostEqual(
+            compute_personality_terminal_scale(ps, gs, "A", "B", 24), 1.3
+        )
+
+    def test_bluff_caught_penalty_does_not_apply_to_honest_loss(self):
+        """When the bet was honest (bet-maker WON), no caught-bluff penalty."""
+        ps = spec_from_dict(
+            {"name": "t", "loss_multiplier": 2.0, "bluff_caught_penalty": 0.5}
+        )
+        # B bet (last bet), A checked. A lost → bet was honest → no penalty.
+        gs = self._gs([{"player": "B", "action_id": 5}])
+        self.assertAlmostEqual(
+            compute_personality_terminal_scale(ps, gs, "A", "A", 24), 2.0
+        )
+
+    def test_hand_type_bias_on_actor_bets(self):
+        """Positive bias = likes: wins bigger, losses smaller."""
+        # Pair action ids 6..11; let's bet 7 (Pair). +0.2 = likes Pair.
+        ps = spec_from_dict({"name": "t", "hand_type_bias": {"Pair": 0.2}})
+        gs = self._gs([{"player": "A", "action_id": 7}])
+        # A won → +0.2 (likes Pair, bigger reward)
+        self.assertAlmostEqual(
+            compute_personality_terminal_scale(ps, gs, "A", "B", 24), 1.2
+        )
+        # A lost → -0.2 (likes Pair, but loss is smaller — penalty reduced by 0.2)
+        gs_lose = self._gs([{"player": "A", "action_id": 7}])
+        self.assertAlmostEqual(
+            compute_personality_terminal_scale(ps, gs_lose, "A", "A", 24), 0.8
+        )
+
+    def test_hand_type_bias_only_on_actor_not_opponent(self):
+        ps = spec_from_dict({"name": "t", "hand_type_bias": {"Pair": 0.5}})
+        gs = self._gs([{"player": "B", "action_id": 7}])
+        # Opponent bet pair; actor never bet pair → no bias applied.
+        self.assertAlmostEqual(
+            compute_personality_terminal_scale(ps, gs, "A", "B", 24), 1.0
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_personality_train.py
+++ b/tests/test_personality_train.py
@@ -74,6 +74,22 @@ class TestSpecRoundTrip(unittest.TestCase):
         with self.assertRaises(ValueError):
             spec_from_dict({"name": "bad", "obs_blind_spots": ["wibble"]})
 
+    def test_inference_variety_defaults_and_overrides(self):
+        # Defaults: greedy=True (deterministic), head="pi" (avg policy).
+        s = spec_from_dict({"name": "default"})
+        self.assertTrue(s.greedy)
+        self.assertEqual(s.head, "pi")
+        # Explicit overrides round-trip.
+        s2 = spec_from_dict({"name": "soft", "greedy": False, "head": "q"})
+        self.assertFalse(s2.greedy)
+        self.assertEqual(s2.head, "q")
+        round_tripped = spec_from_dict(spec_to_dict(s2))
+        self.assertEqual(round_tripped, s2)
+
+    def test_invalid_head_rejected(self):
+        with self.assertRaises(ValueError):
+            spec_from_dict({"name": "bad", "head": "wibble"})
+
 
 class TestLayoutResolver(unittest.TestCase):
     """The block-slice resolver must match _compute_obs_dim exactly."""

--- a/tests/test_production_agent_routing.py
+++ b/tests/test_production_agent_routing.py
@@ -307,6 +307,11 @@ class PersonalityRoutingChainTest(unittest.TestCase):
         )
 
     def test_personality_prepended_for_multi(self):
+        # For non-team multi-player games, the chain now includes the trained
+        # 1v1 personality ckpt as a fallback before the generic variant
+        # baseline — the 1v1-trained obs schema is compatible with non-team
+        # play, and the design choice is "trained trait is more important
+        # than variant-specific strategic refinement."
         chain = _routing_keys(
             {"deck_size": 24, "jokers": 1},
             n_active=3,
@@ -315,8 +320,34 @@ class PersonalityRoutingChainTest(unittest.TestCase):
         )
         self.assertEqual(
             chain,
-            ["24_multi_zorya", "24_zorya", "24_multi", "24"],
+            ["24_multi_zorya", "24_zorya", "24_1v1_zorya", "24_multi", "24"],
         )
+
+    def test_personality_chain_for_32_deck_multi(self):
+        # Same cross-variant trained-1v1 fallback applies to 32-deck.
+        chain = _routing_keys(
+            {"deck_size": 32, "jokers": 1},
+            n_active=3,
+            players=[],
+            personality="zorya",
+        )
+        self.assertEqual(
+            chain,
+            ["32_multi_zorya", "32_zorya", "32_1v1_zorya", "32_multi", "32"],
+        )
+
+    def test_personality_team_does_not_fall_back_to_1v1(self):
+        # Team mode: the trained 1v1 ckpt has obs_dim 390 (team_aware=False),
+        # incompatible with team obs (398-dim). Routing chain must NOT include
+        # the cross-variant 1v1 fallback so we don't try to load a shape-
+        # mismatched ckpt. Variant-only chain handles team mode.
+        chain = _routing_keys(
+            {"deck_size": 24, "teams": True},
+            n_active=4,
+            players=[],
+            personality="mavka",
+        )
+        self.assertNotIn("24_1v1_mavka", chain[chain.index("24_team_mavka") + 1:])
 
     def test_personality_prepended_for_team(self):
         chain = _routing_keys(

--- a/tests/test_production_agent_routing.py
+++ b/tests/test_production_agent_routing.py
@@ -245,5 +245,129 @@ class ResolveModelPathsTest(unittest.TestCase):
         self.assertEqual(set(out.keys()), {"24"})
 
 
+# ---------------------------------------------------------------------------
+# Personality-keyed routing additions (new in feat/trained-personalities)
+# ---------------------------------------------------------------------------
+
+class PersonalityFilenameRegexTest(unittest.TestCase):
+    """The personality suffix is captured separately from the variant suffix."""
+
+    def test_personality_with_variant(self):
+        self.assertEqual(
+            _model_key_from_filename("nfsp_inference_24_1v1_kupala.pt"),
+            "24_1v1_kupala",
+        )
+        self.assertEqual(
+            _model_key_from_filename("nfsp_inference_24_multi_zorya.pt"),
+            "24_multi_zorya",
+        )
+        self.assertEqual(
+            _model_key_from_filename("nfsp_inference_32_team_leshy.pt"),
+            "32_team_leshy",
+        )
+
+    def test_personality_without_variant(self):
+        # Deck-only + personality (no variant slot).
+        self.assertEqual(
+            _model_key_from_filename("nfsp_inference_24_kupala.pt"),
+            "24_kupala",
+        )
+
+    def test_uppercase_personality_rejected(self):
+        """Personalities are lowercase by convention; reject UPPERCASE entries."""
+        self.assertIsNone(_model_key_from_filename("nfsp_inference_24_KUPALA.pt"))
+        self.assertIsNone(_model_key_from_filename("nfsp_inference_24_1v1_LESHY.pt"))
+
+
+class PersonalityRoutingChainTest(unittest.TestCase):
+    """Routing must prepend personality-keyed candidates when one is resolved.
+
+    The variant-only chain remains the fallback, so sculpted-only
+    personalities (no trained checkpoint) keep routing to the baseline
+    where the existing `personality_action` sculpting layer runs.
+    """
+
+    def test_personality_prepended_for_1v1(self):
+        chain = _routing_keys(
+            {"deck_size": 24, "jokers": 0, "blanks": 0, "common_cards": 0},
+            n_active=2,
+            players=[],
+            personality="kupala",
+        )
+        self.assertEqual(
+            chain,
+            [
+                "24_1v1_kupala",
+                "24_multi_kupala",
+                "24_kupala",
+                "24_1v1",
+                "24_multi",
+                "24",
+            ],
+        )
+
+    def test_personality_prepended_for_multi(self):
+        chain = _routing_keys(
+            {"deck_size": 24, "jokers": 1},
+            n_active=3,
+            players=[],
+            personality="zorya",
+        )
+        self.assertEqual(
+            chain,
+            ["24_multi_zorya", "24_zorya", "24_multi", "24"],
+        )
+
+    def test_personality_prepended_for_team(self):
+        chain = _routing_keys(
+            {"deck_size": 24, "teams": True},
+            n_active=4,
+            players=[],
+            personality="poludnica",
+        )
+        # team gets the most-specific personality key first.
+        self.assertEqual(chain[0], "24_team_poludnica")
+        # Variant-only fallback chain preserved.
+        self.assertIn("24_team", chain)
+        self.assertIn("24_multi", chain)
+        self.assertIn("24", chain)
+
+    def test_personality_chain_for_32_deck(self):
+        chain = _routing_keys(
+            {"deck_size": 32, "jokers": 0, "blanks": 0, "common_cards": 0},
+            n_active=2,
+            players=[],
+            personality="leshy",
+        )
+        self.assertEqual(
+            chain,
+            [
+                "32_1v1_leshy",
+                "32_multi_leshy",
+                "32_leshy",
+                "32_1v1",
+                "32_multi",
+                "32",
+            ],
+        )
+
+    def test_personality_none_falls_back_to_variant_chain(self):
+        """When no personality is resolved, the chain is the original."""
+        chain_a = _routing_keys(
+            {"deck_size": 24}, n_active=2, players=[], personality=None
+        )
+        chain_b = _routing_keys(
+            {"deck_size": 24}, n_active=2, players=[]
+        )
+        self.assertEqual(chain_a, chain_b)
+        self.assertEqual(chain_a, ["24_1v1", "24_multi", "24"])
+
+    def test_chain_is_deduped(self):
+        chain = _routing_keys(
+            {"deck_size": 24}, n_active=2, players=[], personality="mavka"
+        )
+        self.assertEqual(len(chain), len(set(chain)))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_public_priors_filter.py
+++ b/tests/test_public_priors_filter.py
@@ -1,0 +1,120 @@
+"""Unit tests for the inference-time public-priors mask filter.
+
+The filter zeros bet actions whose public-prior probability is effectively
+zero (provably-impossible sets given visible cards alone). The filter never
+touches CHECK and never produces an empty mask.
+"""
+
+import numpy as np
+import torch
+import unittest
+
+from nfsp_ai.production_agent import (
+    _filter_mask_by_public_priors,
+    _PUB_PRIOR_EPSILON,
+)
+
+
+class PublicPriorsFilterTest(unittest.TestCase):
+
+    def _build_mask(self, n_bets, check_id, legal_indices):
+        m = np.zeros(check_id + 1, dtype=np.float32)
+        for i in legal_indices:
+            m[i] = 1.0
+        return torch.from_numpy(m)
+
+    def test_zero_priors_get_masked(self):
+        check_id = 5
+        # All bets legal; priors say only ids 0,2,4 are possible.
+        mask = self._build_mask(5, check_id, [0, 1, 2, 3, 4, 5])
+        pub = [0.5, 0.0, 0.3, 0.0, 0.7]
+        out = _filter_mask_by_public_priors(mask, pub, check_id)
+        self.assertEqual(out[0].item(), 1.0)
+        self.assertEqual(out[1].item(), 0.0)  # filtered (impossible)
+        self.assertEqual(out[2].item(), 1.0)
+        self.assertEqual(out[3].item(), 0.0)  # filtered (impossible)
+        self.assertEqual(out[4].item(), 1.0)
+        self.assertEqual(out[5].item(), 1.0)  # CHECK preserved
+
+    def test_check_action_never_filtered(self):
+        check_id = 3
+        # Mask: all bets + CHECK legal.
+        mask = self._build_mask(3, check_id, [0, 1, 2, 3])
+        # Priors of length check_id (just bets). CHECK has no prior entry.
+        pub = [0.0, 0.0, 0.5]
+        out = _filter_mask_by_public_priors(mask, pub, check_id)
+        self.assertEqual(out[check_id].item(), 1.0)
+
+    def test_priors_longer_than_check_id_ignored(self):
+        check_id = 3
+        mask = self._build_mask(3, check_id, [0, 1, 2, 3])
+        # Pad priors beyond check_id with junk — should be ignored.
+        pub = [0.5, 0.5, 0.5, 999.0, -999.0]
+        out = _filter_mask_by_public_priors(mask, pub, check_id)
+        # Bets stay, CHECK stays.
+        self.assertEqual(out[0].item(), 1.0)
+        self.assertEqual(out[3].item(), 1.0)
+
+    def test_priors_shorter_than_check_id(self):
+        # Defensive: if pub_prior is shorter, only filter the prefix.
+        check_id = 5
+        mask = self._build_mask(5, check_id, [0, 1, 2, 3, 4, 5])
+        pub = [0.0, 0.5, 0.0]  # length 3 of 5
+        out = _filter_mask_by_public_priors(mask, pub, check_id)
+        self.assertEqual(out[0].item(), 0.0)
+        self.assertEqual(out[1].item(), 1.0)
+        self.assertEqual(out[2].item(), 0.0)
+        # Beyond filter prefix, original mask preserved.
+        self.assertEqual(out[3].item(), 1.0)
+        self.assertEqual(out[4].item(), 1.0)
+        self.assertEqual(out[5].item(), 1.0)
+
+    def test_safety_rail_keeps_mask_when_filter_would_empty_it(self):
+        check_id = 3
+        # Only one bet legal (id 1), CHECK illegal (e.g. round resolved).
+        mask = self._build_mask(3, check_id, [1])
+        pub = [0.0, 0.0, 0.0]  # filter would zero everything
+        out = _filter_mask_by_public_priors(mask, pub, check_id)
+        # Original mask preserved by the safety rail.
+        self.assertEqual(out[1].item(), 1.0)
+        self.assertEqual(out.sum().item(), 1.0)
+
+    def test_none_pub_prior_passes_through(self):
+        check_id = 3
+        mask = self._build_mask(3, check_id, [0, 1, 2, 3])
+        out = _filter_mask_by_public_priors(mask, None, check_id)
+        self.assertTrue(torch.equal(out, mask))
+
+    def test_empty_pub_prior_passes_through(self):
+        check_id = 3
+        mask = self._build_mask(3, check_id, [0, 1, 2, 3])
+        out = _filter_mask_by_public_priors(mask, [], check_id)
+        self.assertTrue(torch.equal(out, mask))
+
+    def test_epsilon_threshold(self):
+        check_id = 3
+        mask = self._build_mask(3, check_id, [0, 1, 2, 3])
+        pub = [_PUB_PRIOR_EPSILON / 2, _PUB_PRIOR_EPSILON, _PUB_PRIOR_EPSILON * 10]
+        out = _filter_mask_by_public_priors(mask, pub, check_id)
+        # 0 < eps/2 < eps -> filtered (strict >).
+        self.assertEqual(out[0].item(), 0.0)
+        # exactly eps -> filtered (strict >).
+        self.assertEqual(out[1].item(), 0.0)
+        # > eps -> kept.
+        self.assertEqual(out[2].item(), 1.0)
+
+    def test_only_bets_already_illegal_still_filters_correctly(self):
+        # Bets [0,1] illegal already; bet 2 legal; CHECK legal.
+        # Filter shouldn't accidentally re-enable [0,1].
+        check_id = 3
+        mask = self._build_mask(3, check_id, [2, 3])
+        pub = [0.9, 0.9, 0.9]
+        out = _filter_mask_by_public_priors(mask, pub, check_id)
+        self.assertEqual(out[0].item(), 0.0)
+        self.assertEqual(out[1].item(), 0.0)
+        self.assertEqual(out[2].item(), 1.0)
+        self.assertEqual(out[3].item(), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/eval_ladder.py
+++ b/tools/eval_ladder.py
@@ -250,42 +250,38 @@ def head_to_head(
         random.seed(seed)
         torch.manual_seed(seed)
 
-    env = MyEnv(
-        n_agents=n_players,
-        max_cards=max_cards,
-        deck_size=deck_size,
-        jokers=jokers,
-        blanks=blanks,
-        common_cards=common_cards,
-        card_embedding=card_embedding,
-        history_embedding=history_embedding,
-    )
+    def _make_env(team_aware: bool) -> MyEnv:
+        return MyEnv(
+            n_agents=n_players,
+            max_cards=max_cards,
+            deck_size=deck_size,
+            jokers=jokers,
+            blanks=blanks,
+            common_cards=common_cards,
+            card_embedding=card_embedding,
+            history_embedding=history_embedding,
+            team_aware=team_aware,
+        )
 
-    # Sanity: env obs_dim must match the learner's expected input.
-    # Learners trained with different rules / embeddings have different
-    # obs_dims that aren't recorded in the checkpoint, so configuration
-    # has to be supplied at eval time. Catch the mismatch with a clear
-    # error rather than letting torch raise "mat1 and mat2 shapes ...".
-    probe_obs, _probe_mask, _ = env.reset()
-    if int(probe_obs.shape[-1]) != int(learner.obs_dim):
+    # The env appends an 8-slot team-flag block to the obs when team_aware is
+    # on. That flag isn't recorded in older checkpoints, so probe both ways
+    # and keep whichever matches the learner's input dim (legacy 2p artifacts
+    # need team_aware=False). Mirrors tools/team_eval.py's probe.
+    env = None
+    for ta in (True, False):
+        cand = _make_env(ta)
+        probe_obs, _probe_mask, _ = cand.reset()
+        if int(probe_obs.shape[-1]) == int(learner.obs_dim):
+            env = _make_env(ta)  # fresh env so the first game starts cleanly
+            break
+    if env is None:
         raise ValueError(
             f"Env obs_dim {int(probe_obs.shape[-1])} does not match learner obs_dim "
-            f"{int(learner.obs_dim)} for checkpoint. The checkpoint was trained with "
-            f"different rules (deck_size, jokers, blanks, common_cards) or with embeddings "
-            f"enabled. Re-run with matching --deck-size / --jokers / --blanks / --common-cards "
-            f"flags."
+            f"{int(learner.obs_dim)} for checkpoint (tried team_aware both ways). The "
+            f"checkpoint was trained with different rules (deck_size, jokers, blanks, "
+            f"common_cards) or embeddings. Re-run with matching --deck-size / --jokers / "
+            f"--blanks / --common-cards / --use-*-embeddings flags."
         )
-    # Reset env so the first game starts cleanly.
-    env = MyEnv(
-        n_agents=n_players,
-        max_cards=max_cards,
-        deck_size=deck_size,
-        jokers=jokers,
-        blanks=blanks,
-        common_cards=common_cards,
-        card_embedding=card_embedding,
-        history_embedding=history_embedding,
-    )
 
     rounds_won = rounds_lost = 0
     total_actions = 0

--- a/tools/eval_ladder.py
+++ b/tools/eval_ladder.py
@@ -39,6 +39,7 @@ import torch
 
 # Project imports — assume repo root is on sys.path (run as `python -m tools.eval_ladder`).
 from conservative_ai.agent import ConservativeAgent
+from conservative_crawling_ai.agent import ConservativeCrawlingAgent
 from nfsp_ai.agent import NFSPAgent, NFSPConfig
 from nfsp_ai.nfsp_run_local import MyEnv, _compute_obs_dim
 
@@ -85,6 +86,22 @@ class ConservativeOpponent(Opponent):
     def act(self, game_state, obs, mask):
         try:
             a = ConservativeAgent.determine_action(game_state)
+        except Exception:
+            a = None
+        return _legal_or_random(a, mask)
+
+
+class ConservativeCrawlingOpponent(Opponent):
+    """Pure-Python heuristic that escalates along high-probability bets
+    (uses BOTH private and generic priors, unlike `conservative`). Distinct
+    from `ConservativeOpponent` — different action selection rule. Used by
+    the existing `domovoi` sculpted personality as its delegated source."""
+
+    name = "conservative_crawling"
+
+    def act(self, game_state, obs, mask):
+        try:
+            a = ConservativeCrawlingAgent.determine_action(game_state)
         except Exception:
             a = None
         return _legal_or_random(a, mask)
@@ -140,10 +157,21 @@ class SnapshotOpponent(Opponent):
         self.checkpoint_path = checkpoint_path
         self.name = label or f"snapshot:{os.path.basename(checkpoint_path)}"
         self.device = device or torch.device("cpu")
-        # Tiny buffers — we don't train, but NFSPAgent's __init__ allocates them.
-        cfg = NFSPConfig(rl_capacity=1, sl_capacity=1)
-        self.agent = NFSPAgent(obs_dim, act_dim, device=self.device, cfg=cfg)
+        # Detect hidden width + factorize from the checkpoint so 256-wide and
+        # factorized-head snapshots load correctly (mirrors BRSelfOpponent).
         ckpt = torch.load(checkpoint_path, map_location=self.device, weights_only=False)
+        try:
+            hidden = _detect_hidden_from_checkpoint(ckpt)
+        except Exception:
+            hidden = 128
+        saved_cfg = ckpt.get("cfg") or {}
+        factorize = bool(saved_cfg.get("factorize_action_head", False))
+        if not factorize:
+            q_state = ckpt.get("q") or {}
+            if any(str(k).endswith("bet_head.weight") for k in (q_state.keys() if isinstance(q_state, dict) else [])):
+                factorize = True
+        cfg = NFSPConfig(rl_capacity=1, sl_capacity=1, hidden=hidden, factorize_action_head=factorize)
+        self.agent = NFSPAgent(obs_dim, act_dim, device=self.device, cfg=cfg)
         # Use the inference-relevant subset; tolerate both full and exported payloads.
         if "q" in ckpt:
             self.agent.q.load_state_dict(ckpt["q"])
@@ -456,6 +484,7 @@ def load_learner(checkpoint_path: str, device: Optional[torch.device] = None) ->
 OPPONENT_REGISTRY: Dict[str, Callable[[int, int], Opponent]] = {
     "random": lambda obs_dim, act_dim: RandomOpponent(),
     "conservative": lambda obs_dim, act_dim: ConservativeOpponent(),
+    "conservative_crawling": lambda obs_dim, act_dim: ConservativeCrawlingOpponent(),
     "cfr": lambda obs_dim, act_dim: CFROpponent(),
 }
 

--- a/tools/eval_ladder.py
+++ b/tools/eval_ladder.py
@@ -107,6 +107,51 @@ class ConservativeCrawlingOpponent(Opponent):
         return _legal_or_random(a, mask)
 
 
+class SimpleOpponent(Opponent):
+    """Minimal stochastic strategy: 50% CHECK the previous bet (challenge it),
+    50% raise to the next legal bet (the strict minimum legal raise).
+
+    When CHECK isn't legal (round opening — no bet to challenge yet), always
+    raise. Useful as the "weakest principled bot" benchmark — somewhere
+    between random and conservative."""
+
+    name = "simple"
+
+    def act(self, game_state, obs, mask):
+        legal = mask.nonzero(as_tuple=False).view(-1).tolist()
+        if not legal:
+            return 0
+        check_id = mask.shape[-1] - 1  # CHECK is the last action id by convention
+        non_check_legal = [a for a in legal if a != check_id]
+        check_legal = check_id in legal
+        # 50/50 between CHECK (if legal) and the minimum legal bet.
+        if check_legal and random.random() < 0.5:
+            return check_id
+        if non_check_legal:
+            return min(non_check_legal)
+        return check_id  # safety: only CHECK legal
+
+
+class CheckAlwaysOpponent(Opponent):
+    """Always CHECK when CHECK is legal; otherwise pick the minimum legal bet.
+
+    The "Checkbog" — challenges every bet immediately. Will win when the
+    opponent bluffs (which they often must, to drive a CHECK), and lose
+    when the opponent's bet is honest. Useful as a degenerate-defensive
+    benchmark."""
+
+    name = "check_always"
+
+    def act(self, game_state, obs, mask):
+        legal = mask.nonzero(as_tuple=False).view(-1).tolist()
+        if not legal:
+            return 0
+        check_id = mask.shape[-1] - 1
+        if check_id in legal:
+            return check_id
+        return legal[0]
+
+
 class CFROpponent(Opponent):
     """
     Loads CFR strategy CSVs lazily. If the strategy files aren't present,
@@ -485,6 +530,8 @@ OPPONENT_REGISTRY: Dict[str, Callable[[int, int], Opponent]] = {
     "random": lambda obs_dim, act_dim: RandomOpponent(),
     "conservative": lambda obs_dim, act_dim: ConservativeOpponent(),
     "conservative_crawling": lambda obs_dim, act_dim: ConservativeCrawlingOpponent(),
+    "simple": lambda obs_dim, act_dim: SimpleOpponent(),
+    "check_always": lambda obs_dim, act_dim: CheckAlwaysOpponent(),
     "cfr": lambda obs_dim, act_dim: CFROpponent(),
 }
 

--- a/tools/personality_trait_card.py
+++ b/tools/personality_trait_card.py
@@ -1,0 +1,371 @@
+"""Trait-card generator for trained personality models.
+
+Given a personality-suffixed inference checkpoint (e.g.
+``artifacts/nfsp_inference_24_1v1_kupala.pt``) and the baseline 1v1
+checkpoint, plays N self-play games and emits a Markdown card with the
+quantitative trait profile:
+
+  1. action-frequency profile vs baseline (histogram over hand types + CHECK)
+  2. bluff rate (via shared.game_utils.determine_set_existence)
+  3. CHECK frequency
+  4. adaptivity probe — for personalities with obs blind spots, shuffle the
+     masked obs block at inference; the action distribution must NOT shift
+     significantly if the blind-spot was actually learned
+  5. eval ladder via tools.eval_ladder
+  6. auto-generated one-line trait sentence from the top distinguishing stats
+
+Run from repo root:
+
+  python -m tools.personality_trait_card \\
+    --personality kupala \\
+    --baseline artifacts/nfsp_inference_24_1v1.pt \\
+    --n-games 2000 \\
+    --output eval_results/trait_card_kupala.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections import Counter
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+import torch
+
+from nfsp_ai.nfsp_run_local import MyEnv
+from nfsp_ai.personality_train import (
+    PersonalityTrainSpec,
+    load_spec,
+    resolve_obs_block_slices,
+    spec_from_dict,
+)
+from shared.game_utils import determine_set_existence, get_set_details_from_action_id
+from tools.eval_ladder import load_learner
+
+
+HAND_TYPES = (
+    "High card", "Pair", "Two pairs", "Straight", "Three of a kind",
+    "Full house", "Flush", "Four of a kind", "Straight flush",
+)
+
+
+def _hand_type_of(action_id: int, deck_size: int, check_id: int) -> Optional[str]:
+    if action_id == check_id:
+        return "CHECK"
+    info = get_set_details_from_action_id(int(action_id), int(deck_size))
+    return info.get("set_type") if info else None
+
+
+def _bet_maker_hand(game_state: dict, nick: Optional[str]) -> Optional[list]:
+    if not nick:
+        return None
+    for h in game_state.get("hands", []) or []:
+        if h.get("nickname") == nick:
+            return h.get("hand", []) or []
+    return None
+
+
+def _was_bluff(game_state: dict, bet_maker_nick: str, action_id: int) -> Optional[bool]:
+    """True iff the bet is NOT supported by the bet-maker's hand. None if unknown."""
+    hand = _bet_maker_hand(game_state, bet_maker_nick)
+    if hand is None:
+        return None
+    num_jokers = sum(1 for c in hand if int(c.get("value", 0)) < 0)
+    rules = game_state.get("rules", {}) or {}
+    return not bool(determine_set_existence(hand, int(action_id), rules, num_jokers))
+
+
+def _play_games(
+    learner_under_test,
+    baseline,
+    n_games: int,
+    deck_size: int = 24,
+    n_players: int = 2,
+    max_cards: int = 11,
+    seed: Optional[int] = None,
+    personality_spec: Optional[PersonalityTrainSpec] = None,
+    obs_shuffle_block: Optional[str] = None,
+    card_embedding=None,
+    history_embedding=None,
+) -> Dict[str, Counter]:
+    """Play ``n_games`` rounds with ``learner_under_test`` at seat 0 (the
+    reference) and ``baseline`` at the other seat. Returns counters for the
+    learner-under-test's decisions and the baseline's, separately.
+
+    When ``obs_shuffle_block`` is set, the named obs block is replaced with a
+    random permutation of its values each step — used to verify obs-blind
+    personalities don't actually use those features.
+    """
+    if seed is not None:
+        import random as _r
+        _r.seed(seed)
+        torch.manual_seed(seed)
+        np.random.seed(seed)
+
+    env = MyEnv(
+        n_agents=n_players,
+        max_cards=max_cards,
+        deck_size=deck_size,
+        jokers=0, blanks=0, common_cards=0,
+        card_embedding=card_embedding,
+        history_embedding=history_embedding,
+        personality_spec=personality_spec,
+    )
+
+    learner_actions = Counter()
+    learner_bluffs = [0, 0]      # [bluffs, total bet decisions]
+    baseline_actions = Counter()
+    baseline_bluffs = [0, 0]
+
+    shuffle_slice = None
+    if obs_shuffle_block is not None:
+        layout = resolve_obs_block_slices(env.deck_spec)
+        rng = layout.get(obs_shuffle_block)
+        if rng is not None:
+            shuffle_slice = slice(*rng)
+
+    check_id = int(env.deck_spec.check_action_id)
+
+    for _ in range(n_games):
+        obs, mask, _pid = env.reset()
+        done = False
+        while not done:
+            cp = env.game.get("cp_nickname")
+            ref = env._ref_nick
+            is_learner = (cp == ref)
+            game_state = env.game
+
+            if shuffle_slice is not None:
+                obs = obs.clone()
+                blk = obs[shuffle_slice].clone().numpy()
+                np.random.shuffle(blk)
+                obs[shuffle_slice] = torch.from_numpy(blk)
+
+            agent = learner_under_test if is_learner else baseline
+            action = int(agent.select_action(obs, mask, use_average_policy=True, greedy=True))
+            # Ensure legal:
+            legal = mask.nonzero(as_tuple=False).view(-1).tolist()
+            if action not in legal:
+                action = int(legal[0]) if legal else 0
+
+            # Log BEFORE step (so bluff oracle sees the pre-step game state).
+            ht = _hand_type_of(action, deck_size, check_id)
+            ctr = learner_actions if is_learner else baseline_actions
+            bluff_ctr = learner_bluffs if is_learner else baseline_bluffs
+            if ht is not None:
+                ctr[ht] += 1
+            if 0 <= action < check_id:
+                blf = _was_bluff(game_state, cp, action)
+                if blf is not None:
+                    bluff_ctr[1] += 1
+                    if blf:
+                        bluff_ctr[0] += 1
+
+            obs, mask, _r, done, _info = env.step(action)
+
+    return {
+        "learner_actions": learner_actions,
+        "learner_bluff_total": learner_bluffs[1],
+        "learner_bluff_count": learner_bluffs[0],
+        "baseline_actions": baseline_actions,
+        "baseline_bluff_total": baseline_bluffs[1],
+        "baseline_bluff_count": baseline_bluffs[0],
+    }
+
+
+def _freq(ctr: Counter) -> Dict[str, float]:
+    total = sum(ctr.values()) or 1
+    return {k: ctr.get(k, 0) / total for k in (*HAND_TYPES, "CHECK")}
+
+
+def _diff_pp(a: Dict[str, float], b: Dict[str, float]) -> Dict[str, float]:
+    return {k: 100 * (a.get(k, 0.0) - b.get(k, 0.0)) for k in a}
+
+
+def _top_deviations(diff_pp: Dict[str, float], n: int = 3) -> list:
+    items = sorted(diff_pp.items(), key=lambda kv: -abs(kv[1]))
+    return items[:n]
+
+
+def _auto_sentence(name: str, diff_pp: Dict[str, float], bluff_pp: float) -> str:
+    """One-line trait sentence from the top-3 distinguishing stats."""
+    top = _top_deviations(diff_pp, n=3)
+    fragments = []
+    for ht, d in top:
+        if abs(d) < 2.0:
+            continue  # noise floor
+        verb = "claims" if ht != "CHECK" else "checks"
+        direction = "more" if d > 0 else "less"
+        fragments.append(f"{verb} {ht} {abs(d):.0f}pp {direction}")
+    if abs(bluff_pp) >= 2.0:
+        fragments.append(f"bluffs {abs(bluff_pp):.0f}pp {'more' if bluff_pp > 0 else 'less'}")
+    if not fragments:
+        return f"{name.capitalize()} plays essentially like the baseline."
+    return f"{name.capitalize()} " + "; ".join(fragments) + " than baseline."
+
+
+def write_card(
+    path: str,
+    name: str,
+    n_games: int,
+    main_stats: Dict,
+    shuffled_stats: Optional[Dict],
+    spec: Optional[PersonalityTrainSpec],
+) -> None:
+    learn_freq = _freq(main_stats["learner_actions"])
+    base_freq = _freq(main_stats["baseline_actions"])
+    diff = _diff_pp(learn_freq, base_freq)
+
+    lb_total = main_stats["learner_bluff_total"] or 1
+    bb_total = main_stats["baseline_bluff_total"] or 1
+    learn_bluff = 100 * main_stats["learner_bluff_count"] / lb_total
+    base_bluff = 100 * main_stats["baseline_bluff_count"] / bb_total
+    bluff_pp = learn_bluff - base_bluff
+
+    sentence = _auto_sentence(name, diff, bluff_pp)
+
+    lines = []
+    lines.append(f"# {name} — trait card")
+    lines.append("")
+    lines.append(f"**{sentence}**")
+    lines.append("")
+    lines.append(f"Sample: {n_games} games (24-deck, 2p, vanilla).  "
+                 f"Personality vs baseline NFSP at seat 0/1.")
+    lines.append("")
+    if spec is not None:
+        lines.append("## Spec")
+        lines.append("```json")
+        from nfsp_ai.personality_train import spec_to_dict
+        import json as _j
+        lines.append(_j.dumps(spec_to_dict(spec), indent=2))
+        lines.append("```")
+        lines.append("")
+    lines.append("## Action-frequency profile (% of decisions)")
+    lines.append("| Bucket | Baseline | Personality | Δ (pp) |")
+    lines.append("|---|---:|---:|---:|")
+    for ht in (*HAND_TYPES, "CHECK"):
+        lines.append(
+            f"| {ht} | {100*base_freq[ht]:.1f} | {100*learn_freq[ht]:.1f} | "
+            f"{diff[ht]:+.1f} |"
+        )
+    lines.append("")
+    lines.append(f"**Bluff rate:** personality {learn_bluff:.1f}%  vs  "
+                 f"baseline {base_bluff:.1f}%  (Δ {bluff_pp:+.1f} pp)")
+    lines.append("")
+
+    if shuffled_stats is not None and spec is not None and spec.obs_blind_spots:
+        s_freq = _freq(shuffled_stats["learner_actions"])
+        s_diff = _diff_pp(learn_freq, s_freq)
+        max_shift = max(abs(v) for v in s_diff.values())
+        verdict = "PASS" if max_shift < 2.0 else "FAIL"
+        lines.append("## Adaptivity probe (obs blind-spot verification)")
+        lines.append(
+            f"Shuffled obs block(s) {list(spec.obs_blind_spots)} at inference; "
+            f"action-distribution shift max = **{max_shift:.1f} pp** "
+            f"({verdict} — threshold 2.0 pp)"
+        )
+        lines.append("")
+        if max_shift >= 2.0:
+            lines.append("Top shifts:")
+            top = sorted(s_diff.items(), key=lambda kv: -abs(kv[1]))[:5]
+            for ht, d in top:
+                lines.append(f"  - {ht}: {d:+.1f} pp")
+            lines.append("")
+
+    lines.append("---")
+    lines.append("*Auto-generated by `tools/personality_trait_card.py`.*")
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--personality", required=True,
+        help="Personality name (e.g. 'kupala'). Used to locate the spec at "
+             "nfsp_ai/personality_specs/<name>.json and the checkpoint at "
+             "artifacts/nfsp_inference_24_1v1_<name>.pt (unless --checkpoint is set).",
+    )
+    parser.add_argument("--checkpoint", default=None,
+                        help="Override the personality checkpoint path.")
+    parser.add_argument("--baseline", default="artifacts/nfsp_inference_24_1v1.pt",
+                        help="Baseline NFSP checkpoint (opponent + comparison).")
+    parser.add_argument("--n-games", type=int, default=2000)
+    parser.add_argument("--deck-size", type=int, default=24)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output", default=None,
+                        help="Output markdown path. Default: "
+                             "eval_results/trait_card_<personality>.md")
+    parser.add_argument(
+        "--use-card-embeddings", nargs="?", const="auto", default="auto",
+        help="Card embedding artifact path or 'auto'.",
+    )
+    parser.add_argument(
+        "--use-history-embeddings", nargs="?", const="auto", default="auto",
+        help="History embedding artifact path or 'auto'.",
+    )
+    args = parser.parse_args(argv)
+
+    name = args.personality.strip().lower()
+    spec_path = f"nfsp_ai/personality_specs/{name}.json"
+    spec = load_spec(spec_path) if os.path.exists(spec_path) else None
+
+    ckpt = args.checkpoint or f"artifacts/nfsp_inference_24_1v1_{name}.pt"
+    if not os.path.exists(ckpt):
+        print(f"error: personality checkpoint not found at {ckpt!r}", file=sys.stderr)
+        return 2
+    if not os.path.exists(args.baseline):
+        print(f"error: baseline checkpoint not found at {args.baseline!r}", file=sys.stderr)
+        return 2
+
+    # Embeddings (required for 1v1 24-deck baselines that were trained with them).
+    from nfsp_ai.nfsp_run_local import (
+        _load_card_embedding, _resolve_card_embedding_path,
+        _load_history_embedding, _resolve_history_embedding_path,
+    )
+    ce = None
+    he = None
+    if args.use_card_embeddings:
+        p = _resolve_card_embedding_path(args.use_card_embeddings, args.deck_size)
+        if p:
+            ce = _load_card_embedding(p, device="cpu")
+    if args.use_history_embeddings:
+        p = _resolve_history_embedding_path(args.use_history_embeddings, args.deck_size)
+        if p:
+            he = _load_history_embedding(p, device="cpu")
+
+    learner = load_learner(ckpt)
+    baseline = load_learner(args.baseline)
+
+    print(f"[trait-card] {name}: playing {args.n_games} games...")
+    main_stats = _play_games(
+        learner, baseline, n_games=args.n_games,
+        deck_size=args.deck_size, seed=args.seed,
+        personality_spec=spec,
+        card_embedding=ce, history_embedding=he,
+    )
+
+    shuffled_stats = None
+    if spec is not None and spec.obs_blind_spots:
+        # Probe the first blind-spot block (representative — composite probes
+        # can be added later if needed).
+        blk = spec.obs_blind_spots[0]
+        print(f"[trait-card] {name}: adaptivity probe on obs block {blk!r}...")
+        shuffled_stats = _play_games(
+            learner, baseline, n_games=max(500, args.n_games // 4),
+            deck_size=args.deck_size, seed=args.seed + 1,
+            personality_spec=spec, obs_shuffle_block=blk,
+            card_embedding=ce, history_embedding=he,
+        )
+
+    out = args.output or f"eval_results/trait_card_{name}.md"
+    write_card(out, name, args.n_games, main_stats, shuffled_stats, spec)
+    print(f"[trait-card] wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/personality_trait_card.py
+++ b/tools/personality_trait_card.py
@@ -189,21 +189,60 @@ def _top_deviations(diff_pp: Dict[str, float], n: int = 3) -> list:
     return items[:n]
 
 
-def _auto_sentence(name: str, diff_pp: Dict[str, float], bluff_pp: float) -> str:
-    """One-line trait sentence from the top-3 distinguishing stats."""
-    top = _top_deviations(diff_pp, n=3)
-    fragments = []
-    for ht, d in top:
-        if abs(d) < 2.0:
-            continue  # noise floor
-        verb = "claims" if ht != "CHECK" else "checks"
-        direction = "more" if d > 0 else "less"
-        fragments.append(f"{verb} {ht} {abs(d):.0f}pp {direction}")
-    if abs(bluff_pp) >= 2.0:
-        fragments.append(f"bluffs {abs(bluff_pp):.0f}pp {'more' if bluff_pp > 0 else 'less'}")
-    if not fragments:
-        return f"{name.capitalize()} plays essentially like the baseline."
-    return f"{name.capitalize()} " + "; ".join(fragments) + " than baseline."
+def _auto_sentence(
+    name: str,
+    diff_pp: Dict[str, float],
+    bluff_pp: float,
+    spec: Optional[PersonalityTrainSpec] = None,
+) -> str:
+    """One-line trait sentence anchored on the spec's mechanism, verified by data.
+
+    Treats a positive CHECK delta specially when ``spec.forbid_check_unless_only``
+    is set: the personality didn't choose to check more, it got *pinned* at the
+    top of the bet ladder. The phrasing makes that distinction so readers don't
+    mistake aggressive bots for passive ones.
+    """
+    cap = name.capitalize()
+    parts = []
+
+    # 1) CHECK delta — phrase depends on whether the spec forbids voluntary CHECK.
+    check_delta = diff_pp.get("CHECK", 0.0)
+    forbids_check = bool(spec and spec.forbid_check_unless_only)
+    if forbids_check and check_delta >= 10:
+        parts.append(
+            f"escalates aggressively and only checks when pinned at the ceiling "
+            f"(forced CHECK {check_delta:+.0f}pp)"
+        )
+    elif check_delta >= 10:
+        parts.append(f"checks far more often ({check_delta:+.0f}pp)")
+    elif check_delta <= -10:
+        parts.append(f"rarely checks ({check_delta:+.0f}pp)")
+
+    # 2) Hand-type deviations (top 2, excluding CHECK).
+    hand_pairs = sorted(
+        ((ht, d) for ht, d in diff_pp.items() if ht != "CHECK"),
+        key=lambda kv: -abs(kv[1]),
+    )
+    used = 0
+    for ht, d in hand_pairs:
+        if used >= 2 or abs(d) < 5:
+            break
+        if d < 0:
+            parts.append(f"rarely claims {ht.lower()} ({d:+.0f}pp)")
+        else:
+            parts.append(f"claims {ht.lower()} far more often ({d:+.0f}pp)")
+        used += 1
+
+    # 3) Bluff rate.
+    if abs(bluff_pp) >= 5:
+        if bluff_pp > 0:
+            parts.append(f"bluffs {bluff_pp:+.0f}pp more often (claims hands it doesn't have)")
+        else:
+            parts.append(f"bluffs {abs(bluff_pp):.0f}pp less often (plays honest)")
+
+    if not parts:
+        return f"**{cap}** plays essentially like the baseline."
+    return f"**{cap}**: " + "; ".join(parts) + "."
 
 
 def write_card(
@@ -224,12 +263,12 @@ def write_card(
     base_bluff = 100 * main_stats["baseline_bluff_count"] / bb_total
     bluff_pp = learn_bluff - base_bluff
 
-    sentence = _auto_sentence(name, diff, bluff_pp)
+    sentence = _auto_sentence(name, diff, bluff_pp, spec)
 
     lines = []
     lines.append(f"# {name} — trait card")
     lines.append("")
-    lines.append(f"**{sentence}**")
+    lines.append(sentence)
     lines.append("")
     lines.append(f"Sample: {n_games} games (24-deck, 2p, vanilla).  "
                  f"Personality vs baseline NFSP at seat 0/1.")


### PR DESCRIPTION
## Summary
- Inference-only mask filter that zeros bet actions whose public-prior probability is effectively 0 (e.g. Full house with 4 cards in play).
- Safety rail: when filtering would empty the mask (CHECK already illegal), the original mask is returned unchanged.
- CHECK is never affected. Training mask is unchanged.

## Why
Trained NFSP occasionally bet provably-impossible sets. That reads as a bug, not a personality. The public-priors observation block already encodes the impossibility — this is just enforcing it at the output.

## Scope
Applies uniformly to baseline, sculpted, and trained personalities. No checkpoint changes, no retraining.

## Test plan
- [x] 9 new unit tests in \`tests/test_public_priors_filter.py\` cover: zero-priors masking, CHECK preservation, prior-length mismatches, safety rail, None/empty input, epsilon boundary.
- [x] Existing \`tests/test_production_agent_routing.py\` passes (41 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)