### PR TITLE
personality specs: redo kupala/poludnica/baba_yaga/czernobog (structural traits)

### DIFF
--- a/nfsp_ai/personality_specs/baba_yaga.json
+++ b/nfsp_ai/personality_specs/baba_yaga.json
@@ -1,8 +1,7 @@
 {
   "name": "baba_yaga",
+  "forbid_hand_types": ["Flush", "Full house", "Four of a kind", "Straight flush"],
   "loss_multiplier": 0.8,
-  "bluff_call_bonus": 0.6,
-  "hand_type_bias": {"Three of a kind": 0.3, "Four of a kind": 0.3},
   "greedy": false,
   "head": "pi"
 }

--- a/nfsp_ai/personality_specs/czernobog.json
+++ b/nfsp_ai/personality_specs/czernobog.json
@@ -1,9 +1,7 @@
 {
   "name": "czernobog",
-  "win_multiplier": 1.5,
-  "loss_multiplier": 0.6,
-  "bluff_caught_penalty": -0.2,
-  "hand_type_bias": {"Straight flush": 0.4, "Four of a kind": 0.4},
+  "forbid_hand_types": ["High card", "Pair", "Two pairs"],
+  "loss_multiplier": 0.8,
   "greedy": false,
   "head": "pi"
 }

--- a/nfsp_ai/personality_specs/kupala.json
+++ b/nfsp_ai/personality_specs/kupala.json
@@ -1,8 +1,8 @@
 {
   "name": "kupala",
-  "hand_type_bias": {"High card": -0.1, "Pair": -0.2, "Two pairs": -0.15},
-  "bluff_call_bonus": 0.3,
-  "bluff_caught_penalty": 0.3,
+  "forbid_hand_types": ["High card", "Pair"],
+  "win_multiplier": 1.2,
+  "loss_multiplier": 1.0,
   "greedy": false,
   "head": "pi"
 }

--- a/nfsp_ai/personality_specs/poludnica.json
+++ b/nfsp_ai/personality_specs/poludnica.json
@@ -1,7 +1,6 @@
 {
   "name": "poludnica",
-  "loss_multiplier": 0.6,
-  "obs_blind_spots": ["history"],
+  "obs_blind_spots": ["history", "last_bet_prob"],
   "greedy": false,
   "head": "pi"
 }


### PR DESCRIPTION
## Summary
Phase-3 audit showed these 4 personalities reverted toward the Blef equilibrium attractor under aggression-leaning reward shaping. Replacing the shaping with structural constraints (mechanism B / C) so traits are enforced.

- **kupala** — forbid {High card, Pair}: never plays small. `win_mult=1.2`.
- **poludnica** — blind to {history, last_bet_prob}: can't track betting.
- **baba_yaga** — forbid {Flush, Full house, Four of a kind, Straight flush}: caps at Straight.
- **czernobog** — forbid {High card, Pair, Two pairs}: big bets or CHECK.

All multipliers in the safe [0.7, 1.4] band per the prior collapse incident.

## Why structural over shaping
Phase-3: every aggression-leaning shaped personality (kupala, poludnica, baba_yaga, czernobog) ended up MORE cautious than baseline. The bluff-caught penalty / loss-aversion gradients are too strong. Structural constraints (mask + obs-blind) don't fight the gradient — they remove options the policy is allowed to choose from.

## Test plan
- [ ] Retraining 24 cells (4 personalities × 6 variants) — queued in background.
- [ ] Phase-1 cfg-stamp validation (60 ckpts).
- [ ] Phase-2 plays-at-all validation.
- [ ] Phase-3 audit with the new specs to confirm the trait is now visible.
- [ ] Deploy with the public-priors filter (PR #71) live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)