### PR TITLE
personalities: fix + distinguish mokosh/triglav; quartile E resamplers

### DIFF
--- a/nfsp_ai/personalities.py
+++ b/nfsp_ai/personalities.py
@@ -146,16 +146,16 @@ PERSONALITIES: dict[str, PersonalityConfig] = {
              "real probability-grounded 'reading', not faked adaptivity.",
     ),
     "mokosh": PersonalityConfig(
-        source="pi", risk=-0.4, guard=0.8, susp=0.4, tempo=-1.5, chaos=-0.2,
-        mood="tighten_late", mood_params={"kr": 0.8, "ks": 0.8},
+        source="pi", risk=-0.4, guard=0.8, susp=0.4, tempo=-2.0, chaos=-0.2,
+        mood="tighten_late", mood_params={"kr": 0.8, "ks": 1.2},
         note="Weaver. Measured minimal raises, concealed; tightens and grows "
              "more suspicious as the game deepens (dangerous late).",
     ),
     "triglav": PersonalityConfig(
-        source="pi", risk=0.0, guard=0.3, susp=0.0, tempo=0.0, chaos=0.0,
+        source="pi", risk=0.0, guard=0.3, susp=0.0, tempo=0.0, chaos=0.3,
         mood="phase_ramp",
-        mood_params={"risk_early": -0.8, "risk_late": 1.0,
-                     "tempo_early": -1.0, "tempo_late": 1.0,
+        mood_params={"risk_early": -1.2, "risk_late": 1.5,
+                     "tempo_early": -1.0, "tempo_late": 1.5,
                      "guard_early": 0.5, "guard_late": 0.0},
         note="Strategist. Three modes by game depth: conservative early, "
              "analytical mid, aggressive late ('all paths converge').",

--- a/nfsp_ai/personality_specs/domovoi.json
+++ b/nfsp_ai/personality_specs/domovoi.json
@@ -1,9 +1,6 @@
 {
   "name": "domovoi",
-  "loss_multiplier": 1.5,
-  "bluff_caught_penalty": 0.6,
-  "bluff_call_bonus": 0.3,
-  "hand_type_bias": {"High card": 0.1, "Pair": 0.15, "Two pairs": 0.1},
+  "opponent_honesty_bias": 0.4,
   "greedy": false,
   "head": "pi"
 }

--- a/nfsp_ai/personality_specs/mokosh.json
+++ b/nfsp_ai/personality_specs/mokosh.json
@@ -1,0 +1,7 @@
+{
+  "name": "mokosh",
+  "forbid_hand_types": ["Full house", "Four of a kind", "Straight flush"],
+  "loss_multiplier": 0.8,
+  "greedy": false,
+  "head": "pi"
+}

--- a/nfsp_ai/personality_specs/rusalka.json
+++ b/nfsp_ai/personality_specs/rusalka.json
@@ -1,7 +1,8 @@
 {
   "name": "rusalka",
-  "hand_type_bias": {"Pair": 0.2, "Straight flush": 0.4, "Four of a kind": 0.3},
+  "hand_type_bias": {"Pair": 0.4, "Straight flush": 0.7, "Four of a kind": 0.5},
   "bluff_caught_penalty": 0.2,
+  "opponent_honesty_bias": 0.3,
   "greedy": false,
   "head": "pi"
 }

--- a/nfsp_ai/personality_specs/triglav.json
+++ b/nfsp_ai/personality_specs/triglav.json
@@ -1,0 +1,7 @@
+{
+  "name": "triglav",
+  "obs_blind_spots": ["private_priors"],
+  "forbid_hand_types": ["High card"],
+  "greedy": false,
+  "head": "pi"
+}

--- a/nfsp_ai/personality_train.py
+++ b/nfsp_ai/personality_train.py
@@ -499,6 +499,15 @@ def resample_to_honest(
         return a
 
 
+def _legal_bet_ids(legal_mask, check_action_id: int) -> list:
+    """Return the sorted list of legal BET action ids (CHECK excluded)."""
+    if hasattr(legal_mask, "detach"):
+        mask_arr = legal_mask.detach().cpu().numpy()
+    else:
+        mask_arr = np.asarray(legal_mask)
+    return [aid for aid in range(int(check_action_id)) if mask_arr[aid] > 0]
+
+
 def resample_to_aggressive(
     intended_action: int,
     legal_mask,
@@ -508,17 +517,29 @@ def resample_to_aggressive(
     rng,
 ) -> int:
     """With probability ``aggression_bias``, replace the opponent's intended
-    action with the HIGHEST legal bet (max-escalation). CHECK is never
-    overridden (CHECK is the round-ending signal, not an escalation choice).
+    action with a uniform pick from the **top quartile** of legal bets.
+    CHECK is never overridden (CHECK is the round-ending signal, not an
+    escalation choice).
 
-    Used in mechanism E to train a bot against an always-escalating
+    Earlier versions of this resampler picked the single MAX legal bet,
+    which collapsed the opponent's action distribution to a deterministic
+    point and overfit the trained policy off-distribution (POC 2026-06-09:
+    mokosh CHK 0.066, bluff 0.877, wr 0.054). Quartile sampling preserves
+    the diversity the trained policy needs to generalise while still
+    pushing the opponent's distribution clearly upward.
+
+    Used in mechanism E to train a bot against an always-aggressive
     opponent — the bot's optimal response is patient defence (CHECK more
     often, don't overcommit, let escalators tire themselves out). At
-    inference vs an actual passive / Conservative opponent, this trait
-    presents as the bot being measurably more defensive than baseline.
+    inference vs an actual non-aggressive opponent, the trait presents as
+    the bot being measurably more defensive than baseline.
 
-    If the intended action is already the max legal bet (or if no bets are
-    legal at all, only CHECK), the intended action is returned unchanged.
+    Boundary behaviour:
+      - If fewer than 4 legal bets exist, the "top quartile" is taken to
+        be all legal bets at or above the median index — this preserves
+        the upward shift even when the action space is small.
+      - If no legal bets exist (only CHECK), the intended action is
+        returned unchanged.
     """
     a = int(intended_action)
     if aggression_bias <= 0.0 or a == int(check_action_id):
@@ -528,18 +549,22 @@ def resample_to_aggressive(
             return a
     except Exception:
         return a
-    if hasattr(legal_mask, "detach"):
-        mask_arr = legal_mask.detach().cpu().numpy()
-    else:
-        mask_arr = np.asarray(legal_mask)
-    max_bet = -1
-    for aid in range(int(check_action_id) - 1, -1, -1):
-        if mask_arr[aid] > 0:
-            max_bet = aid
-            break
-    if max_bet < 0 or max_bet == a:
+    legal = _legal_bet_ids(legal_mask, check_action_id)
+    if not legal:
         return a
-    return int(max_bet)
+    # Top quartile: indices in [3/4 * n, n). When n < 4 this collapses to
+    # the upper half; when n == 1 it's that single bet.
+    n = len(legal)
+    cutoff = max(0, (3 * n) // 4)
+    upper = legal[cutoff:]
+    if not upper:
+        upper = legal[len(legal) // 2:]   # defensive fallback
+    if not upper:
+        return a
+    try:
+        return int(rng.choice(upper))
+    except Exception:
+        return int(upper[-1])
 
 
 def resample_to_passive(
@@ -551,17 +576,27 @@ def resample_to_passive(
     rng,
 ) -> int:
     """With probability ``passivity_bias``, replace the opponent's intended
-    action with CHECK if legal, else with the LOWEST legal bet.
+    action with a passive choice — either CHECK (if legal) or a uniform
+    pick from the **bottom quartile** of legal bets. When CHECK is legal,
+    we pick it 50% of the time and bottom-quartile-bet the other 50%; when
+    CHECK is illegal, we always pick from the bottom quartile.
+
+    Earlier versions deterministically returned CHECK (or the single MIN
+    legal bet when CHECK was illegal), which collapsed the opponent's
+    action distribution and overfit the trained policy off-distribution
+    (POC 2026-06-09: triglav CHK 0.525, bluff 0.179, wr 0.244 — trait
+    inverted). The 50/50 mix + quartile sampling preserves diversity.
 
     Used in mechanism E to train a bot against a perpetually-passive
     opponent — the bot's optimal response is to press hard: open
     aggressively, escalate, treat opponents as foldable. At inference
-    against an actual non-passive opponent, this trait presents as the bot
-    being measurably more aggressive than baseline (higher opening bets,
-    lower CHECK rate, more bluffs).
+    against an actual non-passive opponent, the trait presents as the bot
+    being measurably more aggressive than baseline.
 
-    If the intended action is already CHECK (or CHECK is legal and that's
-    what we'd resample to), returns the intended action unchanged.
+    Boundary behaviour:
+      - If fewer than 4 legal bets exist, the "bottom quartile" is taken
+        to be all legal bets at or below the median index.
+      - If no legal bets exist (only CHECK is legal), CHECK is returned.
     """
     a = int(intended_action)
     if passivity_bias <= 0.0 or a == int(check_action_id):
@@ -575,14 +610,31 @@ def resample_to_passive(
         mask_arr = legal_mask.detach().cpu().numpy()
     else:
         mask_arr = np.asarray(legal_mask)
-    # Prefer CHECK if legal.
-    if mask_arr[int(check_action_id)] > 0:
+    check_legal = bool(mask_arr[int(check_action_id)] > 0)
+    legal = _legal_bet_ids(legal_mask, check_action_id)
+    if check_legal and (not legal):
         return int(check_action_id)
-    # Else lowest legal bet.
-    for aid in range(int(check_action_id)):
-        if mask_arr[aid] > 0:
-            return int(aid)
-    return a
+    # Choose between CHECK (50%) and a bottom-quartile bet (50%) when both
+    # are available. When CHECK is illegal, always sample a bottom-quartile
+    # bet.
+    if check_legal:
+        try:
+            if rng.random() < 0.5:
+                return int(check_action_id)
+        except Exception:
+            return int(check_action_id)
+    if not legal:
+        # CHECK was the only legal action (handled above) — defensive.
+        return a
+    n = len(legal)
+    cutoff = max(1, (n + 3) // 4)   # ceil(n/4)
+    lower = legal[:cutoff]
+    if not lower:
+        lower = legal[: max(1, n // 2)]   # defensive fallback
+    try:
+        return int(rng.choice(lower))
+    except Exception:
+        return int(lower[0])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_opponent_honesty_bias.py
+++ b/tests/test_opponent_honesty_bias.py
@@ -213,6 +213,9 @@ class HookTest(unittest.TestCase):
 
 
 class AggressionResamplerTest(unittest.TestCase):
+    """Quartile-sample redesign (2026-06-09). At full bias, output lands
+    uniformly in the top quartile of legal bets — not a single point —
+    preserving the diversity the trained policy needs to generalise."""
 
     def test_zero_bias_passthrough(self):
         mask = _legal_all(check_id=88)
@@ -222,16 +225,40 @@ class AggressionResamplerTest(unittest.TestCase):
         )
         self.assertEqual(out, 10)
 
-    def test_full_bias_picks_max_legal(self):
+    def test_full_bias_stays_in_top_quartile(self):
+        # 88 legal bets [0..87]; top quartile cutoff = floor(3*88/4) = 66.
+        # All resampled actions must land in [66, 87].
         mask = _legal_all(check_id=88)
-        # Forbid action ids 80..87, so max legal bet is 79.
-        for aid in range(80, 88):
-            mask[aid] = 0.0
-        out = resample_to_aggressive(
-            intended_action=10, legal_mask=mask, check_action_id=88,
-            aggression_bias=1.0, rng=random.Random(0),
-        )
-        self.assertEqual(out, 79)
+        seen = set()
+        rng = random.Random(0)
+        for _ in range(400):
+            out = resample_to_aggressive(
+                intended_action=10, legal_mask=mask, check_action_id=88,
+                aggression_bias=1.0, rng=rng,
+            )
+            seen.add(out)
+        # All outputs in the upper quartile.
+        self.assertTrue(seen.issubset(set(range(66, 88))), msg=f"out: {seen}")
+        # And there's genuine spread (not a single point).
+        self.assertGreaterEqual(len(seen), 5,
+            msg=f"quartile sampling collapsed to {seen}")
+
+    def test_full_bias_partial_legal(self):
+        # Legal bets [10..29] (20 bets). Top quartile cutoff = 15 -> [25..29]
+        # (positions 15..19 in `legal` list, which are bets 25..29).
+        mask = np.zeros(89, dtype=np.float32)
+        for aid in range(10, 30):
+            mask[aid] = 1.0
+        seen = set()
+        rng = random.Random(7)
+        for _ in range(200):
+            out = resample_to_aggressive(
+                intended_action=10, legal_mask=mask, check_action_id=88,
+                aggression_bias=1.0, rng=rng,
+            )
+            seen.add(out)
+        self.assertTrue(seen.issubset({25, 26, 27, 28, 29}), msg=f"out: {seen}")
+        self.assertGreaterEqual(len(seen), 3)
 
     def test_check_never_overridden(self):
         mask = _legal_all(check_id=88)
@@ -244,15 +271,28 @@ class AggressionResamplerTest(unittest.TestCase):
     def test_no_legal_bets_passthrough(self):
         # Only CHECK is legal.
         mask = np.zeros(89, dtype=np.float32); mask[88] = 1.0
-        # Intended is a bet that's illegal — function should not crash.
         out = resample_to_aggressive(
             intended_action=10, legal_mask=mask, check_action_id=88,
             aggression_bias=1.0, rng=random.Random(0),
         )
         self.assertEqual(out, 10)
 
+    def test_single_legal_bet(self):
+        # Only one bet (id 5) and CHECK legal. Quartile collapses to the
+        # one bet.
+        mask = np.zeros(89, dtype=np.float32); mask[5] = 1.0; mask[88] = 1.0
+        out = resample_to_aggressive(
+            intended_action=5, legal_mask=mask, check_action_id=88,
+            aggression_bias=1.0, rng=random.Random(0),
+        )
+        # The only top-quartile pick is the single legal bet itself.
+        self.assertEqual(out, 5)
+
 
 class PassivityResamplerTest(unittest.TestCase):
+    """Quartile-sample redesign (2026-06-09). At full bias, 50/50 split
+    between CHECK (when legal) and a uniform pick from the bottom quartile
+    of legal bets."""
 
     def test_zero_bias_passthrough(self):
         mask = _legal_all(check_id=88)
@@ -262,24 +302,56 @@ class PassivityResamplerTest(unittest.TestCase):
         )
         self.assertEqual(out, 20)
 
-    def test_full_bias_picks_check_if_legal(self):
+    def test_full_bias_50_50_check_and_bottom_quartile(self):
+        # 88 legal bets [0..87] + CHECK. Bottom quartile bets are [0..21]
+        # (ceil(88/4) = 22 entries). At full bias we should see ~50% CHECK
+        # and ~50% bottom-quartile bets.
         mask = _legal_all(check_id=88)
-        out = resample_to_passive(
-            intended_action=20, legal_mask=mask, check_action_id=88,
-            passivity_bias=1.0, rng=random.Random(0),
-        )
-        self.assertEqual(out, 88)
+        rng = random.Random(0)
+        n = 800
+        n_check = 0
+        n_other = 0
+        bet_seen = set()
+        for _ in range(n):
+            out = resample_to_passive(
+                intended_action=50, legal_mask=mask, check_action_id=88,
+                passivity_bias=1.0, rng=rng,
+            )
+            if out == 88:
+                n_check += 1
+            else:
+                n_other += 1
+                bet_seen.add(out)
+        # CHECK fraction roughly 50%.
+        frac = n_check / n
+        self.assertGreater(frac, 0.40, msg=f"CHECK frac {frac:.2f}")
+        self.assertLess(frac, 0.60, msg=f"CHECK frac {frac:.2f}")
+        # All non-CHECK outputs in bottom quartile.
+        self.assertTrue(bet_seen.issubset(set(range(0, 22))),
+            msg=f"non-quartile: {bet_seen}")
+        # And spread across that quartile.
+        self.assertGreaterEqual(len(bet_seen), 5)
 
-    def test_check_illegal_falls_back_to_lowest_bet(self):
-        # CHECK illegal; only bets in [5, 10] legal.
+    def test_check_illegal_picks_bottom_quartile_only(self):
+        # CHECK illegal; only bets [5..29] legal (25 bets). Bottom quartile
+        # = first ceil(25/4) = 7 -> bets {5,6,7,8,9,10,11}.
         mask = np.zeros(89, dtype=np.float32)
-        for aid in range(5, 11):
+        for aid in range(5, 30):
             mask[aid] = 1.0
-        out = resample_to_passive(
-            intended_action=10, legal_mask=mask, check_action_id=88,
-            passivity_bias=1.0, rng=random.Random(0),
-        )
-        self.assertEqual(out, 5)
+        rng = random.Random(11)
+        seen = set()
+        n_check = 0
+        for _ in range(200):
+            out = resample_to_passive(
+                intended_action=25, legal_mask=mask, check_action_id=88,
+                passivity_bias=1.0, rng=rng,
+            )
+            if out == 88:
+                n_check += 1
+            else:
+                seen.add(out)
+        self.assertEqual(n_check, 0, msg="CHECK was illegal; never pick it")
+        self.assertTrue(seen.issubset(set(range(5, 12))), msg=f"out: {seen}")
 
     def test_already_check_unchanged(self):
         mask = _legal_all(check_id=88)
@@ -290,6 +362,7 @@ class PassivityResamplerTest(unittest.TestCase):
         self.assertEqual(out, 88)
 
     def test_partial_bias_split(self):
+        # At 0.5 bias: ~50% stay at 20, ~50% resample. Wide CI.
         mask = _legal_all(check_id=88)
         kept = 0; n = 400
         rng = random.Random(13)
@@ -301,8 +374,8 @@ class PassivityResamplerTest(unittest.TestCase):
             if out == 20:
                 kept += 1
         frac = kept / n
-        self.assertGreater(frac, 0.25)
-        self.assertLess(frac, 0.75)
+        self.assertGreater(frac, 0.30)
+        self.assertLess(frac, 0.70)
 
 
 class SpecValidationTest(unittest.TestCase):
@@ -349,20 +422,36 @@ class HookDispatchTest(unittest.TestCase):
             self.check_action_id = 88
             self.personality_spec = spec
 
-    def test_aggression_routes_to_max(self):
+    def test_aggression_routes_to_top_quartile(self):
         spec = PersonalityTrainSpec(name="x", opponent_aggression_bias=1.0)
         env = self._StubEnv("L", "O", self._StubDeckSpec(spec))
         mask = _legal_all(check_id=88)
-        # Max legal bet is 87 when full mask.
+        # 88 legal bets; top quartile = [66..87]. Output must land there.
         out = maybe_apply_opponent_honesty_bias(env, mask, 10, random.Random(0))
-        self.assertEqual(out, 87)
+        self.assertGreaterEqual(out, 66)
+        self.assertLessEqual(out, 87)
 
-    def test_passivity_routes_to_check(self):
+    def test_passivity_routes_to_check_or_bottom_quartile(self):
+        # Post-quartile-redesign: at full bias, passivity 50/50s between
+        # CHECK and a uniform pick from the bottom quartile of legal bets.
+        # Run many trials, confirm both CHECK and at least one bottom-
+        # quartile bet appear in the output set, and nothing outside.
         spec = PersonalityTrainSpec(name="x", opponent_passivity_bias=1.0)
         env = self._StubEnv("L", "O", self._StubDeckSpec(spec))
         mask = _legal_all(check_id=88)
-        out = maybe_apply_opponent_honesty_bias(env, mask, 10, random.Random(0))
-        self.assertEqual(out, 88)
+        seen = set()
+        rng = random.Random(0)
+        for _ in range(200):
+            out = maybe_apply_opponent_honesty_bias(env, mask, 50, rng)
+            seen.add(out)
+        # Allowed: CHECK (88) or bottom-quartile bets [0..21].
+        allowed = set(range(0, 22)) | {88}
+        self.assertTrue(seen.issubset(allowed), msg=f"out: {seen}")
+        # Both modes should appear.
+        self.assertIn(88, seen, msg="CHECK never picked")
+        self.assertTrue(
+            any(0 <= a < 22 for a in seen),
+            msg="bottom-quartile bet never picked")
 
     def test_learner_action_never_modified_by_any_knob(self):
         for field_name in ("opponent_honesty_bias",


### PR DESCRIPTION
## Summary
- **triglav**: forbid {High card} only + C-blind private_priors — removes the Pair-forbid opener trap (24_1v1 game-wr 0.00–0.04 → 0.667 row mean)
- **mokosh**: forbid {Full house, 4oak, Straight flush} + loss_mult 0.8 — Flush kept as terminal-depth escalation outlet (vs dazhbog/porevit 0.06/0.04 → 0.39/0.35; tier #4)
- domovoi → pure honesty-E 0.4; rusalka → A+E hybrid (already trained Jun 9)
- mechanism E aggression/passivity resamplers: deterministic point → top/bottom-quartile sampling; tests rewritten distributional
- sculpt divergence for mokosh/triglav (32-deck fallback differentiation)

## Evidence
- 12 variant ckpts trained (max_cards pinned 11 via control plane), gated at game level n=5000 across 8 matrix configs; uniqueness 0.97→1.91 (triglav), pair distance 2.12 — svetovid cluster broken
- Full evidence: `runs/.distinct_pivot/` (queue scripts, train logs, heatmaps, trial evals)
- Deployed to `blef-aiagent-nfsp` 2026-06-12 (image digest e8194d05, ckpt hashes verified image↔local, smoke pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)