### PR TITLE
personalities: declone rusalka/domovoi, uplift triglav, de-hazard mavka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,4 @@ cfr_ai/analysis/data/
 
 # Isolated experiment out-roots (strategies live on the box; local pulls are scratch)
 cfr_ai/exp_*/
+TrialRules.swift

--- a/docs/phase_plan.md
+++ b/docs/phase_plan.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-The user runs a Blef AI project at `/Users/adriangolian/work/blef_ai`, with NFSP (Heinrich & Silver 2016) as the active learning approach. They asked for a no-flattery deep dive: what's actually wrong, which choices were made by intuition rather than evidence, and what concretely makes this bot strong.
+This Blef AI project uses NFSP (Heinrich & Silver 2016) as the active learning approach. This document is a no-flattery deep dive: what's actually wrong, which choices were made by intuition rather than evidence, and what concretely makes this bot strong.
 
 Blef is a Polish set-claiming card game (rules in `Blef_game_readme_rules.md`). Each round, players take turns making a **bet** (a claim that a particular **set** — pair / two pair / straight / full house / flush / etc. — exists in the *union* of all players' cards), strictly more **senior** than the previous bet. The only round-ending action is **check**: the checker calls out the previous bettor's claim. If the pool satisfies the last bet, the checker loses; otherwise the bettor loses. Loser gains a card next round and starts it. A player at the card cap who loses is eliminated. Game ends with one survivor. 24-card deck has 88 sets (89 actions including CHECK); 32-card deck has 160 sets (161 actions). Variants: jokers, blanks, common cards.
 
@@ -156,11 +156,11 @@ After Phase 0 you will know which of these actually moves exploitability. Apply 
 
 ## Critical files
 
-- `/Users/adriangolian/work/blef_ai/nfsp_ai/agent.py` — 1862 lines; SL/RL gating, Q-loss, `ReplayBuffer.gpow`, `_flush_nstep`, schedules.
-- `/Users/adriangolian/work/blef_ai/nfsp_ai/nfsp_run_local.py` — env wrapper, observation encoding, `_legal_action_mask` (line 431, public-prior hard-mask), terminal reward (line 1009), round-end-as-done (line 1023).
-- `/Users/adriangolian/work/blef_ai/cfr_ai/agent.py` + `cfr_ai/outputs/*.csv` — *NOTE: `cfr_ai/outputs/` does not exist locally.* CFR strategies are referenced by the agent at `cfr_ai/agent.py:28` (`'cfr_ai/outputs/<hand_sizes>/<key>/<key>.csv'`), but the data lives elsewhere — likely S3 or production storage given the project has Lambda dispatch infrastructure. **Phase 0 precondition:** locate or regenerate CFR strategies, at minimum for 1v1 24-card-deck no-jokers. Without this, the "head-to-head vs CFR" metric is unreachable and the ladder degrades to {random_legal, ConservativeAgent, snapshot-pool}.
-- `/Users/adriangolian/work/blef_ai/shared/probabilities/dynamic_probabilities.py` — calculator whose bugs currently propagate into the action mask via `_legal_action_mask`.
-- `/Users/adriangolian/work/blef_ai/nfsp_ai/embedding/{encoder.py,history.py}` — pretrained artifacts ready for Phase 2.2 integration.
+- `nfsp_ai/agent.py` — 1862 lines; SL/RL gating, Q-loss, `ReplayBuffer.gpow`, `_flush_nstep`, schedules.
+- `nfsp_ai/nfsp_run_local.py` — env wrapper, observation encoding, `_legal_action_mask` (line 431, public-prior hard-mask), terminal reward (line 1009), round-end-as-done (line 1023).
+- `cfr_ai/agent.py` + `cfr_ai/outputs/*.csv` — *NOTE: `cfr_ai/outputs/` does not exist locally.* CFR strategies are referenced by the agent at `cfr_ai/agent.py:28` (`'cfr_ai/outputs/<hand_sizes>/<key>/<key>.csv'`), but the data lives elsewhere — likely S3 or production storage given the project has Lambda dispatch infrastructure. **Phase 0 precondition:** locate or regenerate CFR strategies, at minimum for 1v1 24-card-deck no-jokers. Without this, the "head-to-head vs CFR" metric is unreachable and the ladder degrades to {random_legal, ConservativeAgent, snapshot-pool}.
+- `shared/probabilities/dynamic_probabilities.py` — calculator whose bugs currently propagate into the action mask via `_legal_action_mask`.
+- `nfsp_ai/embedding/{encoder.py,history.py}` — pretrained artifacts ready for Phase 2.2 integration.
 
 ---
 

--- a/nfsp_ai/personalities.py
+++ b/nfsp_ai/personalities.py
@@ -233,15 +233,15 @@ PERSONALITIES: dict[str, PersonalityConfig] = {
         note="Trickster. Per-move chaos swings between genius and nonsense; "
              "self-destructive randomness ('lost already?'). Easiest NFSP god.",
     ),
-    # --- Caretaker (TRAINED NFSP, replaces the conservative_crawling delegate) - #
+    # --- House spirit (sculpt-only overlay on the baseline NFSP policy) ------- #
     "domovoi": PersonalityConfig(
         source="pi", risk=0.5, guard=-0.5, susp=-0.4, tempo=0.8, chaos=1.8,
         note="House spirit. Sculpt-only silly: high chaos (erratic but "
              "in-distribution moves), readable (negative guard), gullible "
-             "(negative susp), overexcited raises (tempo). Trained ckpts "
-             "retired 2026-06-13 (runs/.bog_program/retired_domovoi/) — the "
-             "honesty-trained caretaker was too strong for the laughing "
-             "house-spirit art. 'The house laughs with you.'",
+             "(negative susp), overexcited raises (tempo). Deliberately not a "
+             "trained personality — a strong honesty-trained caretaker plays "
+             "against the laughing house-spirit character. 'The house laughs "
+             "with you.'",
     ),
 }
 

--- a/nfsp_ai/personalities.py
+++ b/nfsp_ai/personalities.py
@@ -235,13 +235,13 @@ PERSONALITIES: dict[str, PersonalityConfig] = {
     ),
     # --- Caretaker (TRAINED NFSP, replaces the conservative_crawling delegate) - #
     "domovoi": PersonalityConfig(
-        source="pi",
-        note="Caretaker. Trained NFSP biased toward loss-aversion + honest "
-             "simple claims (high card, pair, two pairs) + bluff-call bonus. "
-             "Replaces the previous conservative_crawling delegate. The "
-             "sculpt knobs are zero (no overlay); the trained-personality "
-             "checkpoint (artifacts/nfsp_inference_24_1v1_domovoi.pt) drives "
-             "the behavior. 'A quiet house hides many things.'",
+        source="pi", risk=0.5, guard=-0.5, susp=-0.4, tempo=0.8, chaos=1.8,
+        note="House spirit. Sculpt-only silly: high chaos (erratic but "
+             "in-distribution moves), readable (negative guard), gullible "
+             "(negative susp), overexcited raises (tempo). Trained ckpts "
+             "retired 2026-06-13 (runs/.bog_program/retired_domovoi/) — the "
+             "honesty-trained caretaker was too strong for the laughing "
+             "house-spirit art. 'The house laughs with you.'",
     ),
 }
 

--- a/nfsp_ai/personality_specs/domovoi.json
+++ b/nfsp_ai/personality_specs/domovoi.json
@@ -1,6 +1,0 @@
-{
-  "name": "domovoi",
-  "opponent_honesty_bias": 0.4,
-  "greedy": false,
-  "head": "pi"
-}

--- a/nfsp_ai/personality_specs/mavka.json
+++ b/nfsp_ai/personality_specs/mavka.json
@@ -1,8 +1,8 @@
 {
   "name": "mavka",
-  "win_multiplier": 0.8,
-  "loss_multiplier": 2.5,
-  "bluff_caught_penalty": 0.5,
+  "win_multiplier": 0.9,
+  "loss_multiplier": 1.0,
+  "bluff_caught_penalty": 0.4,
   "greedy": false,
   "head": "pi"
 }

--- a/nfsp_ai/personality_specs/rusalka.json
+++ b/nfsp_ai/personality_specs/rusalka.json
@@ -1,8 +1,7 @@
 {
   "name": "rusalka",
-  "hand_type_bias": {"Pair": 0.4, "Straight flush": 0.7, "Four of a kind": 0.5},
-  "bluff_caught_penalty": 0.2,
-  "opponent_honesty_bias": 0.3,
+  "obs_blind_spots": ["public_priors"],
+  "bluff_call_bonus": 0.2,
   "greedy": false,
   "head": "pi"
 }

--- a/tools/diagnose_buffer.py
+++ b/tools/diagnose_buffer.py
@@ -17,7 +17,7 @@ Run from repo root:
   python -m tools.diagnose_buffer \\
     --checkpoint runs/<id>/checkpoints/nfsp_blef_NM.pt \\
     --metrics runs/<id>/metrics.csv \\
-    --output runs/.claude_overnight/diagnose_<id>.json
+    --output runs/diagnose_<id>.json
 """
 
 from __future__ import annotations

--- a/tools/disk_watcher.sh
+++ b/tools/disk_watcher.sh
@@ -1,17 +1,20 @@
 #!/usr/bin/env bash
-# Watch /Users disk free space; emit one line on threshold crossings.
+# Watch disk free space; emit one line on threshold crossings.
 # Auto-clears intermediate checkpoints (nfsp_blef_*M.pt, NOT the latest
 # nfsp_blef.pt) from the OLDEST training run dir if free < hard limit.
 #
 # Usage: disk_watcher.sh [WARN_GB] [HARD_GB] [POLL_SEC]
+#   RUNS_DIR env var overrides the runs/ location (default: repo runs/).
 set -euo pipefail
 WARN_GB="${1:-50}"
 HARD_GB="${2:-20}"
 POLL="${3:-300}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNS_DIR="${RUNS_DIR:-${REPO_ROOT}/runs}"
 
 free_gb() {
   # macOS-portable: -g reports in 1G blocks.
-  df -g /Users/adriangolian | awk 'NR==2 {print $4}'
+  df -g "${REPO_ROOT}" | awk 'NR==2 {print $4}'
 }
 
 last_state=""
@@ -25,7 +28,7 @@ while true; do
   fi
   if [ "$state" = "hard" ]; then
     # Find the run dir with the most intermediate ckpts and free one.
-    target=$(find /Users/adriangolian/work/blef_ai/runs -maxdepth 3 -name 'nfsp_blef_*M.pt' -type f 2>/dev/null | head -1)
+    target=$(find "${RUNS_DIR}" -maxdepth 3 -name 'nfsp_blef_*M.pt' -type f 2>/dev/null | head -1)
     if [ -n "$target" ]; then
       sz=$(du -h "$target" | cut -f1)
       rm -f "$target"

--- a/tools/team_curve_logger.py
+++ b/tools/team_curve_logger.py
@@ -48,8 +48,8 @@ def main():
     poll = 120  # seconds; checkpoint saves usually less frequent than this
 
     ckpt = os.path.join(run, "checkpoints", "nfsp_blef.pt")
-    card = f"/Users/adriangolian/work/blef_ai/artifacts/card_embedding_pretrain_{deck}.pt"
-    hist = f"/Users/adriangolian/work/blef_ai/artifacts/history_embedding_pretrain_{deck}.pt"
+    card = os.path.join(_ROOT, "artifacts", f"card_embedding_pretrain_{deck}.pt")
+    hist = os.path.join(_ROOT, "artifacts", f"history_embedding_pretrain_{deck}.pt")
 
     print(f"[{label}] team-curve armed; ckpt={ckpt} games={games} seeds={seeds} poll={poll}s")
     sys.stdout.flush()

--- a/tools/team_eval_curve.sh
+++ b/tools/team_eval_curve.sh
@@ -11,11 +11,12 @@ set -euo pipefail
 DECK="${1:?deck size required}"
 shift
 RUNS=("$@")
-PY="${PY:-/Users/adriangolian/work/blef_ai/venv_nfsp/bin/python}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PY="${PY:-${REPO_ROOT}/venv_nfsp/bin/python}"
 ROOT="${ROOT:-/tmp/blef_train2}"
 
-CARD="/Users/adriangolian/work/blef_ai/artifacts/card_embedding_pretrain_${DECK}.pt"
-HIST="/Users/adriangolian/work/blef_ai/artifacts/history_embedding_pretrain_${DECK}.pt"
+CARD="${REPO_ROOT}/artifacts/card_embedding_pretrain_${DECK}.pt"
+HIST="${REPO_ROOT}/artifacts/history_embedding_pretrain_${DECK}.pt"
 
 GAMES=400
 SEEDS=3


### PR DESCRIPTION
## Summary
Bog-improvement program — 3 promotions + 1 honest negative. Each 24_1v1 candidate bake-off used deep-pin retrains (max_cards 11 via control plane, 6–12M steps), staging export, and a game-level pantheon gate (n=5000). Winners got all 6 routing slots retrained.

| bog | change | strength (24_1v1 roster game-wr) | identity |
|-----|--------|------|----------|
| **rusalka** | C-blind `public_priors` + `bluff_call_bonus 0.2`, dropped honesty-E | 0.44 → **0.63** | check-predator siren |
| **domovoi** | retired trained ckpts → sculpt-only silly (chaos 1.8) | 0.62 → **0.48** | matches the laughing-house-spirit art |
| **triglav** | weights-only, 6M → 12M budget, spec unchanged | panel 0.55 → **0.60** | late-loaded strategist (unchanged trait) |
| **mavka** | **not promoted** — in-band A-shaping can't hold the fear trait vs the deep-Nash attractor (2 cycles). Spec brought in-band to kill the latent `loss 2.5` (eff-3.0) collapse recipe | incumbent serves | — |

**Declone achieved:** domovoi↔rusalka behavior distance **0.65 → 2.14** (was the pantheon's worst clone pair; new lowest is the dazhbog↔porevit rule-bot pair, expected).

## Notes
- `domovoi.json` removed (sculpt-only convention, cf. svetovid/perun). Retired weights archived off-tree.
- `mavka.json` disk spec intentionally differs from the still-served incumbent stamp (stamp wins at serve; disk fix is for future retrains only).
- `TrialRules.swift` gitignored (iOS deliverable for blef_ios_app).

## Deployment
Deployed to `blef-aiagent-nfsp` 2026-06-14 (image sha d8cf11c2). 12 rusalka/triglav ckpts hash-verified image↔local; domovoi confirmed absent (baseline+sculpt); smoke pass across 24/32 + special-card configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)