### PR TITLE
chore: gitignore local cruft, agent scaffolding & generated outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,50 @@ cfr_ai/analysis/data/
 # Isolated experiment out-roots (strategies live on the box; local pulls are scratch)
 cfr_ai/exp_*/
 TrialRules.swift
+
+# ──────────────────────────────────────────────────────────────────────────
+# Local cruft / scratch / generated outputs — keep `git status` usable and
+# keep internal/agent notes out of the (public-bound) repo.
+# ──────────────────────────────────────────────────────────────────────────
+
+# macOS Finder cruft
+.DS_Store
+
+# Claude Code / agent scaffolding (local; CLAUDE.md embeds internal prod notes)
+/CLAUDE.md
+/AGENTS.md
+/.claude-plans/
+
+# Local working notes / handovers (distilled content belongs in real docs)
+/GPT_handover*.txt
+/GPT_improvement_advice*.txt
+/DOCS_STATUS.txt
+
+# Virtualenvs (venv/ already covered above; this catches the suffixed one)
+venv_prof/
+
+# Profiling output
+*.prof
+
+# Build artifacts
+/lambda-layer.zip
+/lambda_function.zip
+
+# Local scratch files / dirs
+/tmpfile
+/remove_files_list.txt
+/out/
+/tempt/
+
+# Local CFR strategy backup (swapped-out May-8 set; live set lives elsewhere)
+cfr_ai/outputs_may8_backup/
+
+# Generated data / eval output (regenerate locally)
+/eval_results/
+/bet_probabilities.csv
+/metadata.csv
+
+# Control-plane local/test files (one per training, never shared)
+/control_plane_*.csv
+/control_plane_test.json
+/control_test.json


### PR DESCRIPTION
## Summary

`.gitignore`-only change. Keeps `git status` usable (the working tree had ~7k untracked files, mostly the `cfr_ai/outputs_may8_backup/` local backup) and keeps internal/agent notes out of the public-bound repo.

## Added patterns

| Category | Patterns |
|---|---|
| macOS cruft | `.DS_Store` |
| Agent scaffolding | `/CLAUDE.md`, `/AGENTS.md`, `/.claude-plans/` |
| Local handover notes | `/GPT_handover*.txt`, `/GPT_improvement_advice*.txt`, `/DOCS_STATUS.txt` |
| Virtualenv / profiling / zips | `venv_prof/`, `*.prof`, `/lambda-layer.zip`, `/lambda_function.zip` |
| Local scratch | `/tmpfile`, `/remove_files_list.txt`, `/out/`, `/tempt/` |
| Generated data / eval output | `/eval_results/`, `/bet_probabilities.csv`, `/metadata.csv`, `/control_plane_*.csv`, `/control_plane_test.json`, `/control_test.json` |
| Local CFR backup | `cfr_ai/outputs_may8_backup/` |

`CLAUDE.md` in particular embeds internal prod details (Lambda image digests, strategy, "uncommitted" state notes) and should not ship publicly.

## Verification

- Each new pattern confirmed to match its target via `git check-ignore`.
- Confirmed **not** ignored (still trackable): `agent.py`, `tools/*.py`, `nfsp_ai/*.py`, `requirements.txt`, `docs/*.md`.
- Deliberately left untouched (look like real source/docs to decide on separately): root `*.py` scripts, `tools/*.py`, `docs/*.md` plans, `deployment/`, prompt files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)