### PR TITLE
docs: NFSP onboarding — experiments, dead-ends, eval gotchas

### DIFF
--- a/docs/nfsp_onboarding/00_dead_ends.md
+++ b/docs/nfsp_onboarding/00_dead_ends.md
@@ -1,0 +1,139 @@
+# Dead ends — experiments that failed, and why
+
+Each entry: what was tried → what happened → root cause → the rule it left behind.
+These cost real time. Don't pay for them twice.
+
+---
+
+## A. Reward / credit-assignment traps
+
+### A1. Actor-relative reward → `avgR ≈ 1` that means nothing (historical, now fixed)
+Early `step()` paid reward only at CHECK with `done=True`, `+1 if loser != actor`.
+Because the *actor* is whoever just pressed CHECK, reward was systematically credited
+to the acting side → `avgR` pinned near **1** regardless of skill, and the agent drifted
+to **spam-CHECK / panic-CHECK**.
+- **Fix adopted:** fixed-perspective reward from a `ref_nick` chosen at `reset()`
+  (`+1 if loser != ref_nick else -1`, zero-sum); per-round episodes; `done` only at
+  round end (not on every CHECK).
+- **Rule:** In balanced self-play, **`avgR ≈ 0` is correct** (symmetry) — don't "fix" it.
+  **`avgR ≈ 1` means the actor-credit bug is back**, not that you're winning. The graph
+  is not your KPI; deterministic eval vs baselines is.
+
+### A2. Don't backfill/n-step on top of broken reward
+Sparse terminal reward is propagated by n-step (n≈5–10) or **round-level MC backfill**
+(overwrite the last K=5–10 transitions with the final fixed-perspective reward). If you
+do this *before* fixing actor-relative reward, you just amplify the bug. Precondition:
+reward must already be fixed-perspective.
+
+### A3. Reward shaping outside [0.7, 1.4] → policy collapse (the canonical disaster)
+**kupala, 4 documented attempts** (`5ab1c27` = "v4"). v1 `win=1.8, loss=0.5,
+forbid_check_unless_only` collapsed to **2.65% vs baseline** (53/1947), mean game length
+2.0 actions. Even gentle `win=1.4, loss=0.7` collapsed (0.026 vs baseline).
+- **Root cause:** the dampened-loss MC return makes max-bet bluffs EV-positive even when
+  they lose 95% of the time → escalation death-spiral; the Nash attractor punishes
+  asymmetric shaping. `hand_type_bias` is **additive per matching bet → it compounds**,
+  so "small" biases aren't small.
+- **Rule:** keep **effective reward scale in [0.7, 1.4]**. The **aggression direction
+  (`win>1, loss<1`) is not a tunable knob in this game** — bake aggression nowhere; keep
+  "snowball/aggressor/reveler" archetypes as *sculpted overlays only*.
+
+### A4. `win_multiplier > loss_multiplier` biases toward CHECK, not aggression (counter-intuitive)
+**czernobog** was specced Terror-aggressive (`win=1.5, loss=0.6, +0.4 bias on SF/4oak,
+bluff_caught=-0.2`) and converged to the **most passive** trained bog (CHECK +25pp,
+bluffs −30pp). In Blef, CHECK is often the highest-EV action, so asymmetric reward
+amplifies every winning path *including* catching bluffs.
+- **Rule:** `loss_multiplier < 1` → **more** checking; `> 1` → **less** checking.
+  **Never reward high-tier bets** — big claims are *exposure, not power*; the strike is
+  the CHECK (`bluff_call_bonus`).
+
+---
+
+## B. Personality-mechanism dead ends
+
+### B1. `forbid_hand_types` on low tiers → opener traps
+The action mask is HARD at train **and** inference. Forbidding the LOW tiers removes the
+only legal opening bets in 1–3-card rounds → forced bluffs → near-unwinnable.
+- **czernobog** forbids bottom-3 (HC/Pair/2P) — **still broken** (game-wr 0.04–0.16 at
+  1v1, opener trap since Jun 4).
+- **triglav (broken)** forbade {HC, Pair} → **0.000 game-wr vs dazhbog**.
+- **mokosh (broken)** forbade top-4 → round-wr ~0.5 but game-wr **0.010 vs dazhbog**,
+  collapsing 0.58→0.01 from 3→11 cards.
+- **Rule:** never forbid the bottom two tiers. Fix recipe that worked (triglav):
+  **forbid {High card} only + C-blind `private_priors`** → row-mean 0.667.
+
+### B2. Mechanism E aggression/passivity bias → trait inversion (failed twice)
+`opponent_aggression_bias` / `opponent_passivity_bias` resample the opponent to a single
+deterministic action. The learner overfits the degenerate distribution and the **trait
+inverts**: mokosh `aggression=0.8` → 0.054 vs baseline, bluff share 0.877 (a *honest*
+read of an all-in opponent); triglav `passivity=0.8` → CHECK 0.525, bluff 0.179.
+- The "smarter" **quartile resampler** (sample from upper/lower quartile of legal bets)
+  was tried next — **also inverted**; it's **uncommitted in the working tree**, bound to
+  nothing. mokosh.json/triglav.json were reverted.
+- **Rule:** only **honesty** bias works in mechanism E (truthful spans a diverse action
+  set; single-action resamplers don't). Don't retry aggression/passivity via resampling.
+
+### B3. Mechanism D (`trust_history` inference override) — empirically inert
+A/B at n=2000 across 4 slices: all deltas within 95% CI (`.trust_eval/results.csv`:
+domovoi 0.362 OFF vs 0.343 ON; kupala 0.303 vs 0.316). A Nash policy is robust to
+single-channel input distortion because the other truth signals are correlated.
+- **Rule:** kept as a tested primitive but **bound to no personality**. Don't build on it.
+
+### B4. mavka `loss_mult 2.5` — out of band (latent)
+`win=0.8, loss=2.5` → ~34.6% (playable but weak) and far outside [0.7, 1.4]. Listed as a
+latent breakage to fix with the triglav recipe.
+
+---
+
+## C. Architecture / training dead ends
+
+### C1. Factorized action head + snapshot-league ("treatment", May-8 bake-off)
+Regressed *with more training* (cfr_mean 0.481@5M → 0.453@9M) and lost to plain "control"
+on every metric (by 0.014/0.022/0.031). The league pool fills with weak historical
+policies and drags opponent quality down.
+- **Rule:** **retired.** The control recipe (W256 + embeddings + η/ε pin, MC Q-regression)
+  is enough. Don't reintroduce a self-play league expecting gains.
+
+### C2. Vestigial TD / target-net machinery
+`fbbd720` committed Q-loss to **Monte-Carlo regression with NO bootstrap/target net**.
+The leftover `tau`/EMA/`hard_target_interval`/n-step-TD knobs are **vestigial for Q**.
+- **Rule:** don't reintroduce bootstrapping assuming the old advice files (which
+  recommend Double-Q + Polyak) are current. They were superseded.
+
+### C3. Triangular RIH (randomize-initial-hands)
+Implemented but **costs early-game**; not in the SOTA recipe (used selectively, e.g. 1v1
+mokosh distinctness retrain, not as a default).
+
+---
+
+## D. Eval-interpretation traps (these make a broken model look fine)
+
+- **Round winrate ≠ game winrate.** A B-mask bog can sit ~0.50 round-level and lose ~99%
+  of *games* (it accumulates cards toward elimination). Always check game-level + per-N
+  depth columns.
+- **In-training `EVALUATION` on 3M fine-tunes only exercises `max_cards ≈ 2`** — it
+  **cannot** detect deep-round or game-level breakage. The trainer's eval opponent can be
+  a frozen self-snapshot → misleading ~100% when both play the same degenerate strategy.
+- **"vs CFR" winrates are contaminated** by CFR's hardcoded fallback (action 87/88) on
+  info-set misses: **44–47% miss at `mc=1` (the noisiest, not mc=11)**, ~27% at mc=11.
+  CFR is **24-deck only** → any 32-deck "vs CFR" number ≈ random opponent; strip it.
+- **morana CFR pantheon cache never auto-invalidates** (`bog_version("morana")` is the
+  constant `delegated:cfr`). After any CFR swap, only re-run cells purge; 24-multi/
+  24-team/32-deck morana cells silently hold stale results. Purge keys manually.
+
+---
+
+## E. Operational burns (process, not modeling)
+
+- **Prod swap on a 2p-only slice (2026-05-08).** Declared `control-15M` "SOTA" and tried
+  to copy it over prod — it was trained only on `(2p, deck=24, j=0, b=0, cc=0)`; prod
+  serves 3p+, jokers, blanks, common cards. Would have regressed coverage. **Never swap
+  prod without full deployment-surface coverage; never say "SOTA" without naming the slice.**
+- **Redundant retrain (2026-05-09).** Launched a 12M run when an existing final ckpt
+  already covered the slot. **Inventory `runs/` and `df -h` first** — you can often export
+  from an existing ckpt in seconds instead of retraining for hours.
+- **Shared control-plane file (2026-05-09).** Two trainings shared one `--control-plane`;
+  tuning one perturbed the other. **One control file per training.**
+- **Parallel dependent FS ops (2026-05-31).** Batched reorg + `mv` + upload in one block;
+  they raced and corrupted the `games/` tree. **Sequence one step per turn.**
+
+See [`04_deployment_and_ops.md`](04_deployment_and_ops.md) for the positive rules.

--- a/docs/nfsp_onboarding/01_personality_mechanisms.md
+++ b/docs/nfsp_onboarding/01_personality_mechanisms.md
@@ -1,0 +1,81 @@
+# Personalities ("bogs") — training mechanisms A–E
+
+16 NFSP personalities + morana (CFR), in `nfsp_ai/personalities.py`. Toolkit:
+`nfsp_ai/personality_train.py`; specs: `nfsp_ai/personality_specs/<name>.json`.
+
+## Two layers — never both at once
+1. **Sculpt overlay** — inference-only logit shaping (`risk/guard/susp/tempo/chaos` +
+   mood ramps, `BETA=0.40`). Used **only when no trained ckpt exists** for the routed config.
+2. **Trained spec** — baked into the weights; mask/blind-spots reapplied symmetrically at
+   serve, sculpting **skipped**. Export stamps `cfg["personality"]` (the stamped spec
+   wins over the on-disk spec at serve time).
+
+## The hard truth about the trait space
+Balanced specs converge near the **Nash equilibrium attractor** (passive, honest,
+simple-hand). The trained-personality *action-distribution* space is **narrower than the
+spec space** — distinct traits exist but are subtle. The only lever that moves a policy
+**meaningfully** off the attractor is mechanism **C**.
+
+## Preference order (softest first)
+**C → A-toward-caution → B → (A+B, risky) → never A-toward-aggression.**
+
+---
+
+## A — terminal reward scaling
+Fields: `win_multiplier`, `loss_multiplier`, `bluff_caught_penalty`, `bluff_call_bonus`,
+`hand_type_bias` (**additive per matching bet → compounds**). Fights the Nash attractor.
+- **HAZARD:** keep effective scale in **[0.7, 1.4]** (kupala-v1 collapse). The aggression
+  direction (`win>1, loss<1`) is structurally unstable — collapses even when gentle.
+- Caution direction (`loss>1, win<1`) is safe → under-betting, defensible.
+- **`win > loss` biases toward CHECK, not aggression** (see dead-end A4).
+- **Never reward high-tier bets.** Positive `hand_type_bias` on SF/4oak is a red flag —
+  *claims are exposure, not power*. Power = `bluff_call_bonus` + credible escalation.
+
+## B — `forbid_hand_types` / `forbid_check_unless_only`
+HARD action mask at train AND inference.
+- **HAZARD:** opener traps (dead-end B1) — **never forbid the bottom two tiers**.
+  `forbid_check_unless_only` removes the only bluff-punisher → collapse.
+- Reliable when the forbidden tiers don't trap the opener (trait verdicts flip to OK in
+  `runs/.phase3_redos_masked`).
+
+## C — `obs_blind_spots`
+Zeroed obs blocks, train + serve. A perceptual deficit the agent learns to play optimally
+*within*. **Hardest to collapse; the only real off-attractor lever.** Only blinds that
+strip non-trivially-recoverable features actually move the policy (e.g. leshy's
+`private_priors + last_bet_prob`).
+
+## D — `trust_history`
+Inference-time prior override. **Empirically inert** (dead-end B3). Bound to nothing.
+
+## E — `opponent_{honesty,aggression,passivity}_bias`
+Training-time opponent resampling (≤1 per spec). Changes the **world model**, not the
+reward; the learner's own seat is never resampled, so the trait reads as a coherent
+worldview.
+- **honesty works** (kupala full 6-variant grid; rusalka). **aggression/passivity fail**
+  → trait inversion (dead-end B2).
+
+---
+
+## Roster status
+
+| bog | status |
+|---|---|
+| kupala | trained, pure-honesty E, all 6 variants validated ✅ |
+| triglav | FIXED (forbid {High card} + C-blind `private_priors`), all 12 slots promoted Jun 11 ✅ |
+| mokosh | FIXED v3 (forbid {FH, 4oak, SF} — Flush left open as a terminal counter-raise outlet — + loss 0.8), all 12 slots promoted ✅ |
+| rusalka, veles, baba_yaga, poludnica, leshy, zorya | trained, healthy |
+| domovoi | trained ckpts **RETIRED 2026-06-13**; **shipped sculpt-only** (caretaker was too strong for the laughing-house-spirit art) → `runs/.bog_program/retired_domovoi/` |
+| **czernobog** | **BROKEN** — bottom-3 opener-trap mask since Jun 4; triglav recipe likely fixes it |
+| **mavka** | latent — `loss_mult 2.5` out of band |
+| perun, svetovid | sculpted-only |
+| dazhbog, porevit | **delegated heuristics — out of scope** (Conservative / ConservativeCrawling) |
+| morana | CFR (V3.2x4); pantheon cache stale outside 24_1v1-plain |
+
+> Validation of E-honesty (kupala): the trust signature (wr vs honest − wr vs bluffer) was
+> consistently positive across all 6 variants (+0.011 … +0.087) — lower bluff rate, longer
+> games, High-card/Full-house bet distribution. "The drunk who believes everyone is honest."
+
+**The recipe that fixed triglav AND mokosh:** 6M fine-tune from `nfsp_inference_24_1v1.pt`,
+`max_cards` **pinned 11** via per-run control plane (engine clamps per game; surfaces
+deep-round breakage the 1→11 curriculum hides), staging export → **game-level pantheon
+gate** → promote only on pass. Keep run dirs.

--- a/docs/nfsp_onboarding/02_eval_gotchas.md
+++ b/docs/nfsp_onboarding/02_eval_gotchas.md
@@ -1,0 +1,50 @@
+# Eval gotchas + the evidence map
+
+The metrics are adversarial — most of them can make a broken model look healthy. This is
+where the hours hide.
+
+## The traps
+
+- **Round winrate ≠ game winrate.** The single biggest one. A B-mask bog can sit ~0.50
+  round-level and lose ~99% of *games* (mokosh-vs-dazhbog: **0.58 game-wr @ 3 cards →
+  0.01 @ 11**). It accumulates cards toward elimination round by round. **Always check
+  game-level winrate AND the per-N depth columns.**
+- **Pin `max_cards = 11` for any personality/spec gate.** The 1→11 curriculum and the
+  in-training `EVALUATION` line on 3M fine-tunes only exercise `max_cards ≈ 2` — they
+  **cannot** see deep-round collapse. Use the per-run control plane to clamp.
+- **`tools/pantheon_matrix.py --n-games` is a misnomer** — it counts **ROUNDS/episodes**,
+  not whole games. Whole games ≈ n/18 (n=5000 → ~280 settled games/cell).
+- **Learner / seat-0 is the forced opener** (structural disadvantage). **Rank only on
+  balanced matrices.** `tools/seat_split_matrices.py` is 1v1-only.
+- **Gate vs the BASELINE snapshot, not the trainer's `EVAL` print.** Use
+  `python -m tools.eval_ladder --opponents snapshot --snapshot-paths <baseline>` (~2k
+  games). Heuristic: ≥~25% vs baseline = playable; ~25–45% = the trait is paying for
+  itself; **<~10% = collapse, redesign the spec.**
+- **The trait card (`tools/personality_trait_card.py`) shows only action distribution +
+  bluff rate** — a policy that loses every game can have a clean card. Treat
+  winrate-vs-baseline as a separate, required check.
+- **"vs CFR" numbers are contaminated.** CFR falls back to action 87/88 on info-set
+  misses: 44–47% miss at `mc=1` (the noisiest depth, not mc=11), ~27% at mc=11. CFR is
+  **24-deck only** → any 32-deck "vs CFR" ≈ random opponent. Strip these.
+- **morana CFR cache never auto-invalidates** (`bog_version` constant `delegated:cfr`).
+  After a CFR swap, only re-run cells update; purge non-24-1v1 morana cache keys manually
+  (`runs/.pantheon_matrix_cache/`).
+- **`tools/behavioral_uniqueness.py` is mask-direction-blind** (5-dim behavior z-distance).
+  `tools/audit_phase3.py` is heavy (~45 min).
+
+## Evidence map — which dir proves what
+**Top-level `eval_results/` is STALE (≤ Jun 1). Ignore it.** The real evidence is in
+hidden `runs/.*` dirs:
+
+| Dir | What it is | Headline result |
+|---|---|---|
+| `runs/.claude_overnight/` | May-8 SOTA bake-off (richest narrative) — `FINAL_REPORT.md`, `SUMMARY.md`, `SOTA_C-5M_pivot.md` | control-15M = SOTA: 0.499 vs CFR (Nash parity), 0.564 vs Conservative, NashConv 0.0147. Treatment (factorize+league) lost. CFR fallback contamination quantified. |
+| `runs/.pantheon_matrix/` | 17×17 round+game matrices, per-N columns, heatmaps | `matrix_deck24_1v1_*_n5000.csv`. morana V3.2x4 rerun → game row-mean 0.30→0.83 (24_1v1). Pre-rerun backup in `pre_cfr_v32x4_backup/`. |
+| `runs/.pantheon_matrix_cache/` | per-cell JSON cache | morana key constant `delegated:cfr` → stale-CFR cache hits off 24_1v1. Purge before trusting. |
+| `runs/.behavioral_uniqueness/` | behavior z-distance, dendrograms | morana most-unique (~7.3); lowest pair domovoi↔rusalka 0.65. Mask-blind. |
+| `runs/.phase3_audit/`, `.phase3_redos_*` | trait verdicts — does behavior match spec? | `trait_verdicts.csv`. Many misses flip to OK once the B-mask is applied (`.phase3_redos_masked`). |
+| `runs/.B_C_pivot/` | Jun-9 B/C mechanism pivot (the masks+blind-spots retrain) | fixed triglav/mokosh/domovoi/rusalka. |
+| `runs/.distinct_pivot/` | Jun 10–11 distinctness retrains (6M, max_cards 11) | exports → `artifacts/staging/`; promote only after game-level gate. |
+| `runs/.bog_program/` | Jun-12 A/B spec search | `baseline_reference.txt`, `panel_results.csv`, `specs/`, `retired_domovoi/`. |
+| `runs/.E_quartile_poc/`, `.kupala_e_poc/`, `.kupala_pureE/` | mechanism-E proofs | E alone is weak (~0.30–0.35 vs conservative); doesn't deliver the trait by itself. |
+| `runs/.trust_eval/` | mechanism-D proof | inert (deltas within CI). |

--- a/docs/nfsp_onboarding/03_training_recipe.md
+++ b/docs/nfsp_onboarding/03_training_recipe.md
@@ -1,0 +1,68 @@
+# Training recipe — what's load-bearing, and what was never built
+
+## The load-bearing "control" recipe (reaches Nash parity)
+- **Net:** W256 hidden (chosen over W128). Card + history **pretrained embeddings**
+  (`artifacts/card_embedding_pretrain_{24,32}.pt` + history encoder). Keep params ~0.5–1.5M.
+- **Q head:** **Monte-Carlo regression, NO bootstrap / target net** (`fbbd720`). Leftover
+  TD/Polyak/`hard_target_interval` knobs are **vestigial** — don't reintroduce bootstrapping.
+- **π head:** average policy via true **reservoir** sampling (uniform over history). Do
+  **not** prioritize SL. Store **behavioral one-hots** in the reservoir (no on-policy leakage).
+- **Episodes:** each **round** is its own episode (`d627754`); reward ±1 at CHECK with
+  `γ^d` shaping, **γ=0.666**. Fixed-perspective from a `ref_nick` (never actor-relative).
+- **Curriculum:** `max_cards` 1→11 over ~29M steps. Short runs never see deep rounds.
+- **Routing:** **specialists + most-specific-first**, not one generalist. Models ~1.5MB;
+  loading many is free.
+- Reaches ~0.499 vs CFR (Nash parity) by ~9M steps; beats Conservative everywhere.
+
+## Credit assignment (sparse terminal reward)
+Reward fires only at round end, so pre-CHECK bets look like noise. Use one (or A+B):
+- **(A) n-step TD**, n≈5–10 (median moves/round). Cheapest.
+- **(B) round-level MC backfill** — overwrite the last K=5–10 transitions with the final
+  fixed-perspective reward; earlier steps keep 0. Works well for sparse round games.
+- **(C) TD(λ)**, λ≈0.9 — principled, more work; skip unless traces already exist.
+- **Precondition:** reward must be fixed-perspective first (see dead-end A1/A2).
+
+## Schedules (starting points / sanity bands; live-tune via control plane)
+Canonical spec: `docs/nfsp_training_playbook.yaml`. Typical bands:
+
+| knob | schedule |
+|---|---|
+| η (anticipatory) | 0.25 (0–10M) → 0.15 → 0.12 → 0.10 (25M). More BR labels early, bias π later. |
+| ε (BR branch only) | 0.20→0.05 over 0–5M; drift to 0.02 by 25M. **Floor 0.05 during early training.** |
+| Q LR | 1e-4 → 7e-5 → 5e-5 → 3e-5 (last ~2M). |
+| π LR | ~1e-4–3e-4 (notes conflict; π is supervised, keep responsive). |
+| replay reuse ρ | target **10–20** (25 temporarily OK, **never >30**). `ρ ≈ batch_rl/(η·train_rl_every)`; steer via `train_rl_every`. |
+| n_step | 5 → 7 (~12–20M) → 10 (deep rounds). On change, `_flush_nstep(force=True)`. |
+| buffers | grow RL & SL to ~1M each by 5M steps. |
+
+## Tripwires (sanity bands — know these)
+- **Q-loss** healthy 0.15–0.6. MA >0.8 for >200k steps → halve Q LR or bump `train_rl_every`.
+- **SL-loss** ~1.8–2.2 in the ~80-action space is fine.
+- **Entropy H(π)** should decline *slowly*. **Collapse to <~0.6 too early = bad** (this is
+  the same failure mode as the kupala reward-shaping collapse). If H(π)<0.6 while
+  SLloss>1.8, add a tiny SL entropy bonus (`+0.001·entropy`) for 1–2M steps.
+- **illegal-action rate** should stay ≈ 0. **avgR ≈ 0 in balanced self-play is correct.**
+
+## Metrics glossary
+`avgR` (≈0 balanced = good, ≈1 = the actor-credit bug) · `win` (reward>0 fraction, ref POV)
+· `len` (steps/episode; too short = degenerate early checks) · `Qloss` · `SLloss` ·
+`H(pi)` (low/fast crash = collapse) · `illegal` (≈0) · `eps` · `RL_buf`/`SL_buf` fill.
+Note: `metrics.csv` has **two rows per step** (BR + behavior); avg_reward/win_rate stderr
+~0.035 — wait for 3+ consecutive rows before reacting.
+
+## Built but check before assuming — and NOT built
+**Shipped:** control plane (JSON watcher, 50k cooldown, pinned overrides persist across
+resume, atomic writes), embeddings (pretrained + wired), profiling toolkit (~470→~4400
+steps/s, `tools/profile_selfplay.py`), team mode (engine + trainer, PR #64).
+
+**Aspirational / NOT implemented (don't assume these exist):**
+- **CHECK-focused curriculum** (`docs/check_focus_training_plan.md`) — terminal-pair
+  buffer, contrastive Q-penalty, aux CHECK-outcome head, CHECK exploration floor. Largely
+  not in code. COA/CAC CHECK metrics are planned, not wired.
+- **Schedule-gating / assertion infra / control-plane CI smoke**
+  (`docs/training_schedule_plan.md`) — mostly not built; schedules trusted by convention.
+- **32-deck:** manager/probabilities/runner/embeddings done, but `probability_table.py`
+  is still 24-only and `prompt_env_32.txt` regeneration is flagged. **CFR has no 32-deck
+  strategies** → morana is useless on 32-deck (recurring blocker).
+- Sparsity-audit / feature-ablation / dueling-head / gradient-diagnostic ideas listed in
+  `docs/model_architecture_plan.md` — not pursued.

--- a/docs/nfsp_onboarding/04_deployment_and_ops.md
+++ b/docs/nfsp_onboarding/04_deployment_and_ops.md
@@ -1,0 +1,66 @@
+# Deployment, serving, prod-safety, and ops hygiene
+
+## Serving chain
+`deployment/lambda_function.py` / `aiagent.py` → root `agent.py` →
+`nfsp_ai/production_agent.py`. Env vars `NFSP_MODEL_PATH / NFSP_GREEDY / …` select
+profiles. **DynamoDB = game-state source of truth**; SQS carries move deadlines; CFR runs
+on separate per-hand-size workers. Live Lambda (eu-west-2):
+`blef-nfsp-lambda:lambda-compatible` (verify current digest with `aws lambda get-function`).
+
+## Routing (`production_agent.py`)
+- **Most-specific-first:** `24_1v1_kupala` → `24_1v1` → `24` → … Personality suffix is
+  optional in the inference-filename regex (`[A-Za-z0-9]+` segments; **hyphenated names
+  are rejected and never loaded**).
+- 1v1 specialists **canonicalize eliminated players away** (n_active collapse).
+- **Cross-variant fallback within a deck, NEVER across decks.**
+- Trained ckpt present → honor stamped `cfg["personality"]` (`greedy`, `head`), **skip
+  sculpting**. No ckpt → fall through to `<deck>_<variant>` + sculpt overlay.
+- PR #71 adds an **inference-only public-priors mask filter**: zeros bet actions whose
+  public-prior ≈ 0 (e.g. Full house with 4 cards in play). CHECK is never touched; a
+  safety rail returns the original mask if filtering empties it. (Trained NFSP was
+  occasionally betting provably-impossible sets — a bug, not a personality.)
+
+## Prod-safety rules (each one is a scar)
+- **No prod swap without full deployment-surface coverage.** Full surface = **3p+,
+  jokers, blanks, common cards.** A candidate must be **trained** (not just evaluated/
+  assumed-to-generalize) on every axis: n_agents (2p/3p/4p), deck 24 AND 32, j/b/cc. If any
+  axis was held at default/zero, **refuse to call it SOTA or swap** until trained or the
+  user explicitly accepts the regression.
+- **"SOTA" requires the slice named.** Never bare "SOTA" — say e.g. "best on
+  (2p, deck=24, j=0, b=0, cc=0)". 2p→3p generalization is a hypothesis, not a metric.
+- **Verify the tested ckpt IS the exported artifact.** Prod serves
+  `artifacts/nfsp_inference_<deck>_<variant>.pt`, **not** run-dir
+  `runs/<id>/checkpoints/nfsp_blef.pt` (often a different snapshot — one observed
+  first-layer maxdiff ~2.86). Compare `q`/`pi` state-dicts with `torch.allclose` before
+  saying "production model". Keep non-prod files OUT of `artifacts/` (deploy rsyncs the
+  whole dir) — stage backups under `runs/.distinct_pivot/artifacts_*`.
+- **Don't overgate authorized prod actions.** When the user says "deploy"/"run it" and
+  `aws sts get-caller-identity` resolves, just run it (incl. `SWAP=1`). The deploy script
+  already has the rails (SWAP=0 default, auth pre-flight). Don't ladder more confirmations.
+- **No parallel dependent FS/upload ops** — sequence reorg → swap → upload, one step per
+  turn; confirm counts are stable (all mutators dead) before the next step.
+
+## Training hygiene
+- **Check disk before AND after every training.** `ls runs/` for a reusable match (export
+  from an existing final ckpt via `eval_ladder.load_learner` + `agent.export_inference` —
+  seconds vs hours); `df -h .` for headroom (runs are 1–8 GB). **Prune run-dir
+  `checkpoints/` (buffers ~5G each) immediately after a verified export.** Surface if free
+  space drops below ~20 GB.
+- **One control-plane file per training.** Never share `--control-plane` across concurrent
+  runs — live tuning couples experiments. Name `cp_<experiment-key>.json`; swap the path
+  when copy-pasting a prior `cmd.txt`. Whitelist: `eta/eps/lr_q/lr_pi/cadence/batch/tau/
+  n_step/max_cards/check_prob/burst`. 50k-step cooldown; pinned overrides persist across resume.
+- **Actively monitor; don't fire-and-forget.** Arm a metric-anomaly watcher (win_rate
+  plateau, avg_reward regression, sl_loss >3.0 or rising, q_loss reversal) with an
+  adjustment policy ready (sl_loss climbing → pulse `sl_learning_off`; plateau → ε→0.05,
+  η→0.40; reward regression → revert; sustained reward <0.45 past 6M of 12M → abort).
+
+## Scope / ownership (do not cross)
+- **`cfr_ai/` is READ-ONLY** (external maintainer). Never `git add cfr_ai/…` or edit it;
+  root `metadata.csv` is also CFR territory. Reading blueprints / calling
+  `cfr_ai.agent.determine_action` is fine. **Report CFR bugs to the maintainer; never patch.**
+- **dazhbog → Conservative, porevit → ConservativeCrawling** (delegated rule bots).
+  **Exclude from all trained/sculpted personality work**, even if a theme fits perfectly.
+- **domovoi shipped sculpt-only** (trained ckpts retired 2026-06-13). The other 11 trained
+  bogs are live. Don't resurrect trained domovoi without re-clearing the "too strong for
+  the character" judgment.

--- a/docs/nfsp_onboarding/README.md
+++ b/docs/nfsp_onboarding/README.md
@@ -1,0 +1,41 @@
+# NFSP onboarding — pick up Blef without re-running dead ends
+
+> Reference for picking up NFSP training, personalities, and serving. Specifics
+> (numbers, `file:line`, roster status) drift over time — verify against current code
+> before relying on them.
+
+**Audience:** a new collaborator taking over NFSP training, personalities, and serving.
+**Goal of this folder:** save you the weeks that were already spent discovering what
+*doesn't* work. Read [`00_dead_ends.md`](00_dead_ends.md) first.
+
+## The one rule, if you read nothing else
+The personality trait card and the in-training `EVALUATION` line both **lie**. A policy
+that loses ~99% of *games* can show a fine action-distribution card and ~0.5 *round*
+winrate. **Always gate on game-level winrate vs the baseline snapshot, with
+`max_cards` pinned at 11** so deep-round collapse can't hide. See
+[`02_eval_gotchas.md`](02_eval_gotchas.md).
+
+## What Blef is (30 seconds)
+Polish bluffing card game. Players hold private cards pooled face-down; they make
+**escalating set-bets** ("there exist two pairs among all cards") that must strictly
+increase in seniority. **CHECK** challenges the last bet → showdown over the union of
+all hands → the loser gains a card. Exceed `max_cards` → eliminated. Tier order to
+memorize: `High card < Pair < Two pair < 3oak < Full house < Flush < 4oak < Straight flush`.
+RL view: each **round** is an episode; reward ±1 at CHECK with `γ^d` shaping (γ=0.666).
+
+## Engines
+NFSP (`nfsp_ai/`, the main one), CFR (`cfr_ai/`, **READ-ONLY**, external maintainer),
+plus rule bots `conservative_ai/`, `conservative_crawling_ai/`, and `gpt_ai/`.
+
+## Read in this order
+1. [`00_dead_ends.md`](00_dead_ends.md) — failed experiments; do not repeat them.
+2. [`01_personality_mechanisms.md`](01_personality_mechanisms.md) — bog training A–E, hazards, roster.
+3. [`02_eval_gotchas.md`](02_eval_gotchas.md) — how the metrics fool you; the evidence map.
+4. [`03_training_recipe.md`](03_training_recipe.md) — the load-bearing recipe, schedules, what's NOT built.
+5. [`04_deployment_and_ops.md`](04_deployment_and_ops.md) — serving, prod-safety, training hygiene, scope.
+
+## Fastest path to ground truth (the real evidence)
+- `runs/.claude_overnight/FINAL_REPORT.md` + `SOTA_C-5M_pivot.md` — the May-8 SOTA bake-off and the CFR-contamination caveats.
+- `docs/personality_deployment_surface.md` — current per-config standings + the deploy gate.
+- `docs/nfsp_training_playbook.yaml` — canonical hyperparameters.
+- **Hidden `runs/.*` dirs are the real eval evidence. Top-level `eval_results/` is stale — ignore it.**


### PR DESCRIPTION
## Summary

Adds `docs/nfsp_onboarding/` — a six-file onboarding set so a new collaborator can pick up NFSP training, personalities, and serving **without re-running known dead-end experiments**. Docs-only; no code changes.

## Contents

| file | covers |
|---|---|
| `README.md` | orientation, read order, where the real eval evidence lives |
| `00_dead_ends.md` | failed experiments + root causes (reward-shaping collapse, opener traps, mechanism-E trait inversion, factorized-head regression, prod-swap burn, …) |
| `01_personality_mechanisms.md` | bog mechanisms A–E, hazards, softest-first order, roster status |
| `02_eval_gotchas.md` | round ≠ game winrate, CFR "vs" contamination, morana cache footgun, evidence-dir map |
| `03_training_recipe.md` | the load-bearing recipe, schedules/tripwires, what was planned but never built |
| `04_deployment_and_ops.md` | serving chain, prod-safety rules, training hygiene, scope/ownership |

## Notes

- Written as timeless reference (no session/provenance stamps, no absolute paths).
- Specifics (numbers, `file:line`, roster) drift — each doc says to verify against current code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)